### PR TITLE
Refactor/navigation drawer

### DIFF
--- a/uni/lib/view/common_widgets/pages_layouts/general/widgets/navigation_drawer.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/widgets/navigation_drawer.dart
@@ -78,7 +78,7 @@ class AppNavigationDrawerState extends State<AppNavigationDrawer> {
         child: Text(logOutText,
             style: Theme.of(context)
                 .textTheme
-                .headline6!
+                .titleLarge!
                 .copyWith(color: Theme.of(context).primaryColor)),
       ),
     );
@@ -132,30 +132,25 @@ class AppNavigationDrawerState extends State<AppNavigationDrawer> {
       }
     }
 
-    return NavigationDrawer(
-      children: <Widget>[
-        Container(
-          padding: const EdgeInsets.only(top: 55.0),
-          child: Column(
-            children: drawerOptions,
-          ),
+    return NavigationDrawer(children: <Widget>[
+      Container(
+        padding: const EdgeInsets.only(top: 55.0),
+        child: Column(
+          children: drawerOptions,
         ),
-        // Logout Button and Theme Switcher positioned at the bottom of the drawer
-        Container(
-          height: 100.0,
-          child: Align(
-            alignment: Alignment.bottomCenter,
-            child: Container(
-              child: Row(
-                children: <Widget>[
-                  Expanded(child: createLogoutBtn()),
-                  createThemeSwitchBtn(),
-                ],
-              ),
-            ),
+      ),
+      const Padding(
+        padding: EdgeInsets.fromLTRB(18, 16, 18, 10),
+        child: Divider(),
+      ),
+      Row(
+        children: <Widget>[
+          Expanded(
+            child: createLogoutBtn(),
           ),
-        ),
-      ],
-    );
+          createThemeSwitchBtn()
+        ],
+      )
+    ]);
   }
 }

--- a/uni/lib/view/common_widgets/pages_layouts/general/widgets/navigation_drawer.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/widgets/navigation_drawer.dart
@@ -132,21 +132,30 @@ class AppNavigationDrawerState extends State<AppNavigationDrawer> {
       }
     }
 
-    return Drawer(
-        child: Column(
+    return NavigationDrawer(
       children: <Widget>[
-        Expanded(
-            child: Container(
+        Container(
           padding: const EdgeInsets.only(top: 55.0),
-          child: ListView(
+          child: Column(
             children: drawerOptions,
           ),
-        )),
-        Row(children: <Widget>[
-          Expanded(child: createLogoutBtn()),
-          createThemeSwitchBtn()
-        ])
+        ),
+        // Logout Button and Theme Switcher positioned at the bottom of the drawer
+        Container(
+          height: 100.0,
+          child: Align(
+            alignment: Alignment.bottomCenter,
+            child: Container(
+              child: Row(
+                children: <Widget>[
+                  Expanded(child: createLogoutBtn()),
+                  createThemeSwitchBtn(),
+                ],
+              ),
+            ),
+          ),
+        ),
       ],
-    ));
+    );
   }
 }

--- a/uni/pubspec.yaml
+++ b/uni/pubspec.yaml
@@ -73,7 +73,6 @@ dependencies:
   percent_indicator: ^4.2.2
   shimmer: ^2.0.0
   material_design_icons_flutter: ^6.0.7096
-
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Closes #683
Now using NavigationDrawer (flutter 3.7) instead of Drawer.

EDIT: i think test_lint.yaml is failing because NavigationDrawer is only in flutter 3.7 while the test is using version 3.3.

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
