### PR TITLE
bump/bump and lock minimum Android SDK version

### DIFF
--- a/uni/android/app/build.gradle
+++ b/uni/android/app/build.gradle
@@ -52,7 +52,7 @@ android {
         applicationId "pt.up.fe.ni.uni"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 19
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
Needed to support some of the plugins we're using. 
With this change, we will drop support for Android versions older than 4.4.

Closes #821 

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
