### PR TITLE
Fix relogin logic

### DIFF
--- a/uni/lib/controller/networking/network_router.dart
+++ b/uni/lib/controller/networking/network_router.dart
@@ -141,8 +141,9 @@ class NetworkRouter {
           NavigationService.logout();
           return Future.error('Login failed');
         }
-
-        session.cookies = newSession.cookies;
+        session
+          ..username = newSession.username
+          ..cookies = newSession.cookies;
         headers['cookie'] = session.cookies;
         return http.get(url.toUri(), headers: headers).timeout(timeout);
       } else {


### PR DESCRIPTION
There was an issue with the relogin logic, that breaks almost every fetcher that depends on the student number on the app. 

When the user login info is saved, the username is saved as `upxxxxxxxxx` being `x` digits. When the app loads, it loads a fake session on `SessionProvider.restoreSession()` with username being the one loaded from user preferences (so therefore it loads `upxxxxxxxxx`) , when `NetworkRouter.getWithCookies` is called for the first time, it will try to do the request but it will know that this session is not valid (because on app start, it will have no cookies) and try to relogin. The cookies are copied from the newSession to the session that was given as an argument. The problem is that, the username stays the same so in the `upxxxxxxxxx` form, and every api to sigarra that needs a student number expects only the number part, breaking almost all fetchers.

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
