### PR TITLE
Make build run on dev and master pushes

### DIFF
--- a/.github/workflows/app_version_integrity.yaml
+++ b/.github/workflows/app_version_integrity.yaml
@@ -2,7 +2,7 @@ on: pull_request
 
 jobs:
   app_version_integrity:
-    name: "Check for app version change"
+    name: "Version integrity"
     runs-on: ubuntu-latest
     env:
       APP_VERSION_PATH: "uni/app_version.txt"

--- a/.github/workflows/format_lint_test.yaml
+++ b/.github/workflows/format_lint_test.yaml
@@ -1,4 +1,7 @@
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches: [master, develop]
 
 env:
   FLUTTER_VERSION: 3.7.2
@@ -6,7 +9,7 @@ env:
 
 jobs:
   format:
-    name: 'Format'
+    name: "Format"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -20,7 +23,7 @@ jobs:
       - run: dart format $(find . -type f -name "*.dart" -a -not -name "*.g.dart") --set-exit-if-changed
 
   lint:
-    name: 'Lint'
+    name: "Lint"
     runs-on: ubuntu-latest
     needs: format
     defaults:
@@ -31,7 +34,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: ${{ env.JAVA_VERSION }}
-          distribution: 'zulu'
+          distribution: "zulu"
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -46,7 +49,7 @@ jobs:
       - run: flutter analyze .
 
   test:
-    name: 'Test'
+    name: "Test"
     runs-on: ubuntu-latest
     needs: lint
     defaults:
@@ -57,7 +60,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: ${{ env.JAVA_VERSION }}
-          distribution: 'zulu'
+          distribution: "zulu"
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 <br>
 <br>
 
-[![Build badge](https://img.shields.io/github/actions/workflow/status/NIAEFEUP/uni/format_lint_test.yaml?style=for-the-badge)](https://github.com/NIAEFEUP/uni/actions)
-[![Deploy badge](https://img.shields.io/github/actions/workflow/status/NIAEFEUP/uni/deploy.yaml?label=Deploy&style=for-the-badge)](https://github.com/NIAEFEUP/uni/actions)
+[![Build badge](https://img.shields.io/github/actions/workflow/status/NIAEFEUP/uni/format_lint_test.yaml?style=for-the-badge&branch=develop)](https://github.com/NIAEFEUP/uni/actions)
+[![Deploy badge](https://img.shields.io/github/actions/workflow/status/NIAEFEUP/uni/deploy.yaml?label=Deploy&style=for-the-badge&branch=develop)](https://github.com/NIAEFEUP/uni/actions)
 
 [![style: very good analysis](https://img.shields.io/badge/style-very_good_analysis-B22C89.svg?style=for-the-badge)](https://pub.dev/packages/very_good_analysis)
 [![License badge](https://img.shields.io/github/license/NIAEFEUP/uni?style=for-the-badge)](https://github.com/NIAEFEUP/uni/blob/develop/LICENSE)


### PR DESCRIPTION
Closes #896 
This makes `format_lint_test` GH action run on `develop` and `master`, with the following tradeoffs:

- pro: status badge always point to stable branch; broken PRs no longer break it
- pro: safeguard in case of admin force push mistake
- pro: allows test coverage to be on the default branch after #898 
- con: some more minutes spent; we never had problems with it

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
