### PR TITLE
Update sentry version

### DIFF
--- a/uni/pubspec.yaml
+++ b/uni/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   path_provider: ^2.0.0
   percent_indicator: ^4.2.2
   provider: ^6.0.4
-  sentry_flutter: ^7.5.2
+  sentry_flutter: ^7.9.0
   shared_preferences: ^2.0.3
   shimmer: ^3.0.0
   sqflite: ^2.0.3


### PR DESCRIPTION
Closes #914 
This was causing `package_info_plus` to be downgrading to a old version (`2.0` and the current one is `4.0`) and crashing `flutter run` on newer versions of flutter (I'm using `3.10.6`). I need someone to test on the current version of flutter used by the project (`3.7`) to see if there aren't any regressions. 

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
