### PR TITLE
Add 'Consultas SASUP' to Useful links and hide prints link under "Úteis" tab

### DIFF
--- a/uni/lib/view/useful_info/widgets/other_links_card.dart
+++ b/uni/lib/view/useful_info/widgets/other_links_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:uni/view/common_widgets/generic_expansion_card.dart';
-// import 'package:uni/view/useful_info/widgets/link_button.dart';
+import 'package:uni/view/useful_info/widgets/link_button.dart';
 
 /// Manages the 'Current account' section inside the user's page (accessible
 /// through the top-right widget with the user picture)
@@ -10,11 +10,15 @@ class OtherLinksCard extends GenericExpansionCard {
   @override
   Widget buildCardContent(BuildContext context) {
     return Column(
-        /*children: const [
-        // LinkButton(title: 'Impressão', link: 'https://print.up.pt')
+      children: const [
+        // LinkButton(title: 'Impressão', link: 'https://print.up.pt'),
         // TODO(Process-ing): Get fixed link
-      ],*/
-        );
+        LinkButton(
+          title: 'Consultas SASUP',
+          link: 'https://www.up.pt/portal/pt/sasup/saude/marcar-consulta/',
+        ),
+      ],
+    );
   }
 
   @override

--- a/uni/lib/view/useful_info/widgets/other_links_card.dart
+++ b/uni/lib/view/useful_info/widgets/other_links_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:uni/view/common_widgets/generic_expansion_card.dart';
-import 'package:uni/view/useful_info/widgets/link_button.dart';
+// import 'package:uni/view/useful_info/widgets/link_button.dart';
 
 /// Manages the 'Current account' section inside the user's page (accessible
 /// through the top-right widget with the user picture)
@@ -10,10 +10,11 @@ class OtherLinksCard extends GenericExpansionCard {
   @override
   Widget buildCardContent(BuildContext context) {
     return Column(
-      children: const [
-        LinkButton(title: 'Impressão', link: 'https://print.up.pt')
-      ],
-    );
+        /*children: const [
+        // LinkButton(title: 'Impressão', link: 'https://print.up.pt')
+        // TODO(Process-ing): Get fixed link
+      ],*/
+        );
   }
 
   @override


### PR DESCRIPTION
Closes #745,  closes #894 

![Screenshot_1692297777](https://github.com/NIAEFEUP/uni/assets/42045371/02678d13-5122-4964-9b4b-610a41f96cb3)

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
