### PR TITLE
Fixed username format while persisting

### DIFF
--- a/uni/lib/model/providers/startup/session_provider.dart
+++ b/uni/lib/model/providers/startup/session_provider.dart
@@ -109,7 +109,7 @@ class SessionProvider extends StateProviderNotifier {
 
     if (persistentSession) {
       await AppSharedPreferences.savePersistentUserInfo(
-        username,
+        session.username,
         password,
         faculties,
       );


### PR DESCRIPTION
SIGARRA's allows login with two forms: upxxxxxxxxx or just the number part. But we should only store the number part because sigarra mandates only the number part in fields like `pv_codigo`. While the session was being created correctly initially, we store into `SharedPreferences` the original format that the user inserts (so if the user chooses a username with up it can break further requests). This bug is also possible because after logging in for the first time, the app will get the user details again from `SharedPreferences` for some reason (which can have the wrong username format and break the ProfileProvider, which in turn breaks all the app) 


# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
