### PR TITLE
Fix overlapping classes bugs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,12 +14,19 @@ jobs:
         with:
           token: ${{ secrets.NIAEFEUPBOT_PAT }}
 
+      - name: Get develop hash
+        if: github.ref == 'refs/heads/master'
+        run: |
+          git fetch origin develop
+          current_hash=$(git rev-parse HEAD)
+          echo "DEVELOPHASH=$current_hash" >> $GITHUB_ENV
+
       - name: Bump flutter patch version
-        if: github.ref == 'refs/heads/develop'
+        if: github.ref == 'refs/heads/develop' || (github.ref == 'refs/heads/master' && $${{github.sha == env.DEVELOPHASH}})
         run: perl -i -pe 's/^(\d+\.\d+\.)(\d+)(\+)(\d+)$/$1.($2+1).($3).($4+1)/e' ${{ env.APP_VERSION_PATH }}
 
       - name: Bump flutter minor version
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && $${{github.sha == env.DEVELOPHASH}}
         run: perl -i -pe 's/^(\d+)(\.)(\d+)(\.)(\d+)(\+)(\d+)$/$1.($2).($3+1).($4).(0).($6).($7+1)/e' ${{ env.APP_VERSION_PATH }}
 
       - name: Copy app version to pubspec

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,9 +32,6 @@ jobs:
       - name: Copy app version to pubspec
         run: cat ${{ env.APP_VERSION_PATH }} | perl -i -pe 's/^(version:\s+)(\d+\.\d+\.\d+\+\d+)$/$1.(<STDIN>)/e' ${{ env.PUBSPEC_PATH }}
 
-      - name: debug cansdo
-        run: git --no-pager diff
-
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "Bump app version [no ci]"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,24 +18,26 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: |
           git fetch origin develop
-          current_hash=$(git rev-parse HEAD)
+          current_hash=$(git rev-parse origin/develop)
           echo "DEVELOPHASH=$current_hash" >> $GITHUB_ENV
 
       - name: Bump flutter patch version
-        if: github.ref == 'refs/heads/develop' || (github.ref == 'refs/heads/master' && $${{github.sha == env.DEVELOPHASH}})
+        if: github.ref == 'refs/heads/develop' || github.sha != env.DEVELOPHASH
         run: perl -i -pe 's/^(\d+\.\d+\.)(\d+)(\+)(\d+)$/$1.($2+1).($3).($4+1)/e' ${{ env.APP_VERSION_PATH }}
 
       - name: Bump flutter minor version
-        if: github.ref == 'refs/heads/master' && $${{github.sha == env.DEVELOPHASH}}
+        if: github.ref == 'refs/heads/master' && github.sha == env.DEVELOPHASH
         run: perl -i -pe 's/^(\d+)(\.)(\d+)(\.)(\d+)(\+)(\d+)$/$1.($2).($3+1).($4).(0).($6).($7+1)/e' ${{ env.APP_VERSION_PATH }}
 
       - name: Copy app version to pubspec
         run: cat ${{ env.APP_VERSION_PATH }} | perl -i -pe 's/^(version:\s+)(\d+\.\d+\.\d+\+\d+)$/$1.(<STDIN>)/e' ${{ env.PUBSPEC_PATH }}
 
+      - name: debug cansdo
+        run: git --no-pager diff
+
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "Bump app version [no ci]"
-
       - name: Propagate master version bump to develop
         if: github.ref == 'refs/heads/master'
         run: git push --force-with-lease origin HEAD:develop

--- a/uni/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_html.dart
+++ b/uni/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_html.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:http/http.dart';
 import 'package:uni/controller/fetchers/schedule_fetcher/schedule_fetcher.dart';
 import 'package:uni/controller/networking/network_router.dart';
@@ -39,8 +40,11 @@ class ScheduleFetcherHtml extends ScheduleFetcher {
     }
 
     final lectures = await Future.wait(
-      lectureResponses
-          .map((response) => getScheduleFromHtml(response, session)),
+      IterableZip(
+        [lectureResponses, NetworkRouter.getBaseUrlsFromSession(session)],
+      ).map(
+        (e) => getScheduleFromHtml(e[0] as Response, session, e[1] as String),
+      ),
     ).then((schedules) => schedules.expand((schedule) => schedule).toList());
 
     lectures.sort((l1, l2) => l1.compare(l2));

--- a/uni/lib/controller/parsers/parser_schedule_html.dart
+++ b/uni/lib/controller/parsers/parser_schedule_html.dart
@@ -11,7 +11,7 @@ import 'package:uni/model/entities/time_utilities.dart';
 Future<List<Lecture>> getOverlappedClasses(
   Session session,
   Document document,
-  Uri uri,
+  String faculty,
 ) async {
   final lecturesList = <Lecture>[];
 
@@ -57,14 +57,14 @@ Future<List<Lecture>> getOverlappedClasses(
       if (href == null) {
         throw Exception();
       }
-      final faculty = uri.path.split('/')[1];
       final response = await NetworkRouter.getWithCookies(
-        'https://${uri.host}/$faculty/$href',
+        '$faculty$href',
         {},
         session,
       );
 
-      final classLectures = await getScheduleFromHtml(response, session);
+      final classLectures =
+          await getScheduleFromHtml(response, session, faculty);
 
       lecturesList.add(
         classLectures
@@ -100,6 +100,7 @@ Future<List<Lecture>> getOverlappedClasses(
 Future<List<Lecture>> getScheduleFromHtml(
   http.Response response,
   Session session,
+  String faculty,
 ) async {
   final document = parse(response.body);
   var semana = [0, 0, 0, 0, 0, 0];
@@ -161,7 +162,7 @@ Future<List<Lecture>> getScheduleFromHtml(
 
   lecturesList
     ..addAll(
-      await getOverlappedClasses(session, document, response.request!.url),
+      await getOverlappedClasses(session, document, faculty),
     )
     ..sort((a, b) => a.compare(b));
 

--- a/uni/lib/controller/parsers/parser_schedule_html.dart
+++ b/uni/lib/controller/parsers/parser_schedule_html.dart
@@ -9,7 +9,10 @@ import 'package:uni/model/entities/session.dart';
 import 'package:uni/model/entities/time_utilities.dart';
 
 Future<List<Lecture>> getOverlappedClasses(
-    Session session, Document document, Uri uri) async {
+  Session session,
+  Document document,
+  Uri uri,
+) async {
   final lecturesList = <Lecture>[];
 
   final monday = DateTime.now().getClosestMonday();
@@ -55,8 +58,11 @@ Future<List<Lecture>> getOverlappedClasses(
         throw Exception();
       }
       final faculty = uri.path.split('/')[1];
-      final response =
-          await NetworkRouter.getWithCookies('https://${uri.host}/$faculty/$href', {}, session);
+      final response = await NetworkRouter.getWithCookies(
+        'https://${uri.host}/$faculty/$href',
+        {},
+        session,
+      );
 
       final classLectures = await getScheduleFromHtml(response, session);
 
@@ -155,7 +161,8 @@ Future<List<Lecture>> getScheduleFromHtml(
 
   lecturesList
     ..addAll(
-        await getOverlappedClasses(session, document, response.request!.url),)
+      await getOverlappedClasses(session, document, response.request!.url),
+    )
     ..sort((a, b) => a.compare(b));
 
   return lecturesList;

--- a/uni/lib/model/entities/lecture.dart
+++ b/uni/lib/model/entities/lecture.dart
@@ -51,10 +51,11 @@ class Lecture {
     String classNumber,
     int occurrId,
   ) {
+    final startTimeList = startTimeString.split(':');
     final startTime = day.add(
       Duration(
-        hours: int.parse(startTimeString.substring(0, 2)),
-        minutes: int.parse(startTimeString.substring(3, 5)),
+        hours: int.parse(startTimeList[0]),
+        minutes: int.parse(startTimeList[1]),
       ),
     );
     final endTime = startTime.add(Duration(minutes: 30 * blocks));

--- a/uni/lib/model/providers/lazy/lecture_provider.dart
+++ b/uni/lib/model/providers/lazy/lecture_provider.dart
@@ -53,7 +53,7 @@ class LectureProvider extends StateProviderNotifier {
 
       _lectures = lectures;
       updateStatus(RequestStatus.successful);
-    } catch (e, stacktrace) {
+    } catch (e) {
       updateStatus(RequestStatus.failed);
     }
   }

--- a/uni/lib/model/providers/lazy/lecture_provider.dart
+++ b/uni/lib/model/providers/lazy/lecture_provider.dart
@@ -53,7 +53,7 @@ class LectureProvider extends StateProviderNotifier {
 
       _lectures = lectures;
       updateStatus(RequestStatus.successful);
-    } catch (e) {
+    } catch (e, stacktrace) {
       updateStatus(RequestStatus.failed);
     }
   }


### PR DESCRIPTION
The overlapping lectures are not completely fixed, because the desired behavior will require a more deep refactor. Now if a overlapping lectures is from a group of classes, the end time will be equal do the start time. I'll create a issue for a more in-depth refactor

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
