### PR TITLE
Hotfix/api parsing for half duration lectures

### DIFF
--- a/uni/lib/controller/parsers/parser_schedule.dart
+++ b/uni/lib/controller/parsers/parser_schedule.dart
@@ -32,9 +32,10 @@ Future<List<Lecture>> parseSchedule(http.Response response) async {
     final secBegin = lecture['hora_inicio'] as int;
     final subject = lecture['ucurr_sigla'] as String;
     final typeClass = lecture['tipo'] as String;
-    // TODO(luisd): this was marked as a double on the develop branch but the
-    //  tests' example api returns an integer. At the moment there are no
-    //  classes so I can't test this.
+    
+    // Note: aula_duracao returns an integer when the lecture is 1 hour long
+    // or 2 hours long and so on. When the lecture is 1.5 hours long, it
+    // returns a double, with the value 1.5. 
     final lectureDuration = lecture['aula_duracao'];
     final blocks = lectureDuration is double
       ? (lectureDuration * 2).toInt()

--- a/uni/lib/controller/parsers/parser_schedule.dart
+++ b/uni/lib/controller/parsers/parser_schedule.dart
@@ -35,7 +35,11 @@ Future<List<Lecture>> parseSchedule(http.Response response) async {
     // TODO(luisd): this was marked as a double on the develop branch but the
     //  tests' example api returns an integer. At the moment there are no
     //  classes so I can't test this.
-    final blocks = (lecture['aula_duracao'] as int) * 2;
+    final lectureDuration = lecture['aula_duracao'];
+    final blocks = lectureDuration is double
+      ? (lectureDuration * 2).toInt()
+      : (lectureDuration as int) * 2;
+
     final room =
         (lecture['sala_sigla'] as String).replaceAll(RegExp(r'\+'), '\n');
     final teacher = lecture['doc_sigla'] as String;

--- a/uni/lib/controller/parsers/parser_schedule.dart
+++ b/uni/lib/controller/parsers/parser_schedule.dart
@@ -32,14 +32,14 @@ Future<List<Lecture>> parseSchedule(http.Response response) async {
     final secBegin = lecture['hora_inicio'] as int;
     final subject = lecture['ucurr_sigla'] as String;
     final typeClass = lecture['tipo'] as String;
-    
-    // Note: aula_duracao returns an integer when the lecture is 1 hour long
+
+    // Note: aula_duracao is an integer when the lecture is 1 hour long
     // or 2 hours long and so on. When the lecture is 1.5 hours long, it
-    // returns a double, with the value 1.5. 
+    // returns a double, with the value 1.5.
     final lectureDuration = lecture['aula_duracao'];
     final blocks = lectureDuration is double
-      ? (lectureDuration * 2).toInt()
-      : (lectureDuration as int) * 2;
+        ? (lectureDuration * 2).toInt()
+        : (lectureDuration as int) * 2;
 
     final room =
         (lecture['sala_sigla'] as String).replaceAll(RegExp(r'\+'), '\n');


### PR DESCRIPTION
This PR introduces a hotfix to a problem where the API parsing throws an exception when aula_duracao, in the API response, is a double (1.5 for a lecture that lasts for 1h30min). This was done by checking if the value is a double and, if so, multiply it by two and only then cast it to an integer, instead of converting the result to an integer.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
