### PR TITLE
fix: schedule html parser not parsing all courses

### DIFF
--- a/uni/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_html.dart
+++ b/uni/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_html.dart
@@ -21,10 +21,13 @@ class ScheduleFetcherHtml extends ScheduleFetcher {
   @override
   Future<List<Lecture>> getLectures(Session session, Profile profile) async {
     final dates = getDates();
-    final urls = getEndpoints(session);
+    final baseUrls = NetworkRouter.getBaseUrlsFromSession(session);
+
     final lectureResponses = <Tuple2<Response, String>>[];
-    for (final course in profile.courses) {
-      for (final url in urls) {
+    for (final baseUrl in baseUrls) {
+      final url = '${baseUrl}hor_geral.estudantes_view';
+
+      for (final course in profile.courses) {
         final response = await NetworkRouter.getWithCookies(
           url,
           {
@@ -35,7 +38,7 @@ class ScheduleFetcherHtml extends ScheduleFetcher {
           },
           session,
         );
-        lectureResponses.add(Tuple2(response, url));
+        lectureResponses.add(Tuple2(response, baseUrl));
       }
     }
 

--- a/uni/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_html.dart
+++ b/uni/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_html.dart
@@ -39,12 +39,15 @@ class ScheduleFetcherHtml extends ScheduleFetcher {
       }
     }
 
+    final baseUrls = NetworkRouter.getBaseUrlsFromSession(session);
+
     final lectures = await Future.wait(
-      IterableZip(
-        [lectureResponses, NetworkRouter.getBaseUrlsFromSession(session)],
-      ).map(
-        (e) => getScheduleFromHtml(e[0] as Response, session, e[1] as String),
-      ),
+      lectureResponses
+        // FIXME: baseUrls[0] is a hack, because the course can be taught in more than one faculty
+        .map((e) => [e, baseUrls[0]])
+        .map(
+          (e) => getScheduleFromHtml(e[0] as Response, session, e[1] as String),
+        ),
     ).then((schedules) => schedules.expand((schedule) => schedule).toList());
 
     lectures.sort((l1, l2) => l1.compare(l2));

--- a/uni/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_html.dart
+++ b/uni/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_html.dart
@@ -43,11 +43,12 @@ class ScheduleFetcherHtml extends ScheduleFetcher {
 
     final lectures = await Future.wait(
       lectureResponses
-        // FIXME: baseUrls[0] is a hack, because the course can be taught in more than one faculty
-        .map((e) => [e, baseUrls[0]])
-        .map(
-          (e) => getScheduleFromHtml(e[0] as Response, session, e[1] as String),
-        ),
+          // FIXME: baseUrls[0] is a hack, because the course can be taught in more than one faculty
+          .map((e) => [e, baseUrls[0]])
+          .map(
+            (e) =>
+                getScheduleFromHtml(e[0] as Response, session, e[1] as String),
+          ),
     ).then((schedules) => schedules.expand((schedule) => schedule).toList());
 
     lectures.sort((l1, l2) => l1.compare(l2));

--- a/uni/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_html.dart
+++ b/uni/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_html.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:http/http.dart';
 import 'package:uni/controller/fetchers/schedule_fetcher/schedule_fetcher.dart';
 import 'package:uni/controller/networking/network_router.dart';
@@ -43,7 +42,8 @@ class ScheduleFetcherHtml extends ScheduleFetcher {
 
     final lectures = await Future.wait(
       lectureResponses
-          // FIXME: baseUrls[0] is a hack, because the course can be taught in more than one faculty
+          // FIXME: baseUrls[0] is a hack, because the course can be
+          // taught in more than one faculty
           .map((e) => [e, baseUrls[0]])
           .map(
             (e) =>


### PR DESCRIPTION
This PR fixes an issue with the schedule HTML parser where the parser would only parse the classes from the first course of each student.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
