### PR TITLE
fix: exams not showing up

### DIFF
--- a/uni/lib/controller/fetchers/course_units_fetcher/all_course_units_fetcher.dart
+++ b/uni/lib/controller/fetchers/course_units_fetcher/all_course_units_fetcher.dart
@@ -8,8 +8,9 @@ import 'package:uni/model/entities/session.dart';
 class AllCourseUnitsFetcher {
   Future<List<CourseUnit>?> getAllCourseUnitsAndCourseAverages(
     List<Course> courses,
-    Session session,
-  ) async {
+    Session session, {
+    List<CourseUnit>? currentCourseUnits,
+  }) async {
     final allCourseUnits = <CourseUnit>[];
 
     for (final course in courses) {
@@ -17,6 +18,7 @@ class AllCourseUnitsFetcher {
         final courseUnits = await _getAllCourseUnitsAndCourseAveragesFromCourse(
           course,
           session,
+          currentCourseUnits: currentCourseUnits,
         );
         allCourseUnits.addAll(courseUnits.where((c) => c.enrollmentIsValid()));
       } catch (e) {
@@ -30,8 +32,9 @@ class AllCourseUnitsFetcher {
 
   Future<List<CourseUnit>> _getAllCourseUnitsAndCourseAveragesFromCourse(
     Course course,
-    Session session,
-  ) async {
+    Session session, {
+    List<CourseUnit>? currentCourseUnits,
+  }) async {
     final url = '${NetworkRouter.getBaseUrl(course.faculty!)}'
         'fest_geral.curso_percurso_academico_view';
     final response = await NetworkRouter.getWithCookies(
@@ -41,6 +44,10 @@ class AllCourseUnitsFetcher {
       },
       session,
     );
-    return parseCourseUnitsAndCourseAverage(response, course);
+    return parseCourseUnitsAndCourseAverage(
+      response,
+      course,
+      currentCourseUnits: currentCourseUnits,
+    );
   }
 }

--- a/uni/lib/controller/parsers/parser_course_units.dart
+++ b/uni/lib/controller/parsers/parser_course_units.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:html/parser.dart';
 import 'package:http/http.dart' as http;
 import 'package:uni/model/entities/course.dart';
@@ -6,8 +7,9 @@ import 'package:uni/utils/url_parser.dart';
 
 List<CourseUnit> parseCourseUnitsAndCourseAverage(
   http.Response response,
-  Course course,
-) {
+  Course course, {
+  List<CourseUnit>? currentCourseUnits,
+}) {
   final document = parse(response.body);
   final table = document.getElementById('tabelapercurso');
   if (table == null) {
@@ -68,11 +70,16 @@ List<CourseUnit> parseCourseUnitsAndCourseAverage(
         continue;
       }
 
+      final matchingCurrentCourseUnit = currentCourseUnits
+          ?.firstWhereOrNull((element) => element.code == codeName);
+
       final courseUnit = CourseUnit(
         schoolYear:
             '${firstSchoolYear + yearIncrement}/${firstSchoolYear + yearIncrement + 1}',
         occurrId: int.parse(occurId),
-        abbreviation: codeName,
+        code: codeName,
+        abbreviation: matchingCurrentCourseUnit?.abbreviation ??
+            codeName, // FIXME: this is not the abbreviation
         status: status,
         grade: grade,
         ects: double.parse(ects),

--- a/uni/lib/model/providers/lazy/exam_provider.dart
+++ b/uni/lib/model/providers/lazy/exam_provider.dart
@@ -74,7 +74,7 @@ class ExamProvider extends StateProviderNotifier {
   }
 
   Future<void> setFilteredExams(Map<String, bool> newFilteredExams) async {
-    unawaited(AppSharedPreferences.saveFilteredExams(filteredExamsTypes));
+    unawaited(AppSharedPreferences.saveFilteredExams(newFilteredExams));
     _filteredExamsTypes = Map<String, bool>.from(newFilteredExams);
     notifyListeners();
   }

--- a/uni/lib/model/providers/startup/profile_provider.dart
+++ b/uni/lib/model/providers/startup/profile_provider.dart
@@ -112,8 +112,12 @@ class ProfileProvider extends StateProviderNotifier {
 
   Future<void> fetchCourseUnitsAndCourseAverages(Session session) async {
     final courses = profile.courses;
-    final allCourseUnits = await AllCourseUnitsFetcher()
-        .getAllCourseUnitsAndCourseAverages(profile.courses, session);
+    final allCourseUnits =
+        await AllCourseUnitsFetcher().getAllCourseUnitsAndCourseAverages(
+      profile.courses,
+      session,
+      currentCourseUnits: profile.courseUnits,
+    );
 
     if (allCourseUnits != null) {
       _profile.courseUnits = allCourseUnits;

--- a/uni/lib/view/home/widgets/exam_card.dart
+++ b/uni/lib/view/home/widgets/exam_card.dart
@@ -112,11 +112,13 @@ class ExamCard extends GenericCard {
       children: [
         if (locale == AppLocale.pt) ...[
           DateRectangle(
-            date: '${exam.weekDay}, ${exam.begin.day} de ${exam.month}',
+            date: '''${exam.weekDay(locale)}, '''
+                '''${exam.begin.day} de ${exam.month(locale)}''',
           )
         ] else ...[
           DateRectangle(
-            date: '${exam.weekDay}, ${exam.begin.day} ${exam.month}',
+            date: '''${exam.weekDay(locale)}, '''
+                '''${exam.begin.day} ${exam.month(locale)}''',
           )
         ],
         RowContainer(


### PR DESCRIPTION
This PR fixes the problem where exams won't show up for students.

Firstly, an issue was fixed with the course unit parsing where the abbreviations of the course units were not parsed (the code was used instead).
Furthermore, this also fixed an issue with the exam filter not being saved properly.
Lastly, this also fixed an issue with the exam card where the weekday and month functions were not being called.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
