### PR TITLE
Unused months removal

### DIFF
--- a/uni/lib/controller/local_storage/app_exams_database.dart
+++ b/uni/lib/controller/local_storage/app_exams_database.dart
@@ -11,20 +11,6 @@ import 'package:uni/model/entities/exam.dart';
 class AppExamsDatabase extends AppDatabase {
   AppExamsDatabase()
       : super('exams.db', [_createScript], onUpgrade: migrate, version: 5);
-  Map<String, String> months = {
-    'Janeiro': '01',
-    'Fevereiro': '02',
-    'Março': '03',
-    'Abril': '04',
-    'Maio': '05',
-    'Junho': '06',
-    'Julho': '07',
-    'Agosto': '08',
-    'Setembro': '09',
-    'Outubro': '10',
-    'Novembro': '11',
-    'Dezembro': '12'
-  };
 
   static const _createScript = '''
 CREATE TABLE exams(id TEXT, subject TEXT, begin TEXT, end TEXT,


### PR DESCRIPTION
Closes #996 
Removes `months` variable, which was not used.

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
