### PR TITLE
Encapsulate Url Launch with Toast

### DIFF
--- a/uni/lib/controller/networking/url_launcher.dart
+++ b/uni/lib/controller/networking/url_launcher.dart
@@ -1,0 +1,18 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:uni/generated/l10n.dart';
+import 'package:uni/view/common_widgets/toast_message.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+Future<void> launchUrlWithToast(BuildContext context, String url) async {
+  final validUrl = Uri.parse(url);
+  if (url != '' && canLaunchUrl(validUrl) as bool) {
+    await launchUrl(Uri.parse(url));
+  } else {
+    await ToastMessage.error(
+      context,
+      S.of(context).no_link,
+    );
+  }
+}

--- a/uni/lib/generated/intl/messages_en.dart
+++ b/uni/lib/generated/intl/messages_en.dart
@@ -180,6 +180,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("No favorite restaurants"),
         "no_info": MessageLookupByLibrary.simpleMessage(
             "There is no information to display"),
+        "no_link":
+            MessageLookupByLibrary.simpleMessage("We couldn\'t open the link"),
         "no_menu_info": MessageLookupByLibrary.simpleMessage(
             "There is no information available about meals"),
         "no_menus": MessageLookupByLibrary.simpleMessage(

--- a/uni/lib/generated/intl/messages_pt_PT.dart
+++ b/uni/lib/generated/intl/messages_pt_PT.dart
@@ -181,6 +181,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Sem restaurantes favoritos"),
         "no_info": MessageLookupByLibrary.simpleMessage(
             "Não existem informações para apresentar"),
+        "no_link": MessageLookupByLibrary.simpleMessage(
+            "Não conseguimos abrir o link"),
         "no_menu_info": MessageLookupByLibrary.simpleMessage(
             "Não há informação disponível sobre refeições"),
         "no_menus": MessageLookupByLibrary.simpleMessage(

--- a/uni/lib/generated/l10n.dart
+++ b/uni/lib/generated/l10n.dart
@@ -1028,6 +1028,16 @@ class S {
     );
   }
 
+  /// `We couldn't open the link`
+  String get no_link {
+    return Intl.message(
+      'We couldn\'t open the link',
+      name: 'no_link',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Other links`
   String get other_links {
     return Intl.message(

--- a/uni/lib/l10n/intl_en.arb
+++ b/uni/lib/l10n/intl_en.arb
@@ -200,6 +200,8 @@
   "@no_selected_exams": {},
   "occurrence_type": "Type of occurrence",
   "@occurrence_type": {},
+  "no_link": "We couldn't open the link",
+  "@no_link": {},
   "other_links": "Other links",
   "@other_links": {},
   "pass_change_request": "For security reasons, passwords must be changed periodically.",

--- a/uni/lib/l10n/intl_pt_PT.arb
+++ b/uni/lib/l10n/intl_pt_PT.arb
@@ -200,6 +200,8 @@
   "@no_selected_exams": {},
   "occurrence_type": "Tipo de ocorrência",
   "@occurrence_type": {},
+  "no_link": "Não conseguimos abrir o link",
+  "@no_link": {},
   "other_links": "Outros links",
   "@other_links": {},
   "pass_change_request": "Por razões de segurança, as palavras-passe têm de ser alteradas periodicamente.",

--- a/uni/lib/view/about/widgets/terms_and_conditions.dart
+++ b/uni/lib/view/about/widgets/terms_and_conditions.dart
@@ -2,15 +2,15 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:uni/controller/load_static/terms_and_conditions.dart';
+import 'package:uni/controller/networking/url_launcher.dart';
 import 'package:uni/generated/l10n.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 class TermsAndConditions extends StatelessWidget {
   const TermsAndConditions({super.key});
 
   @override
   Widget build(BuildContext context) {
-    var termsAndConditionsSaved = S.of(context).loading_terms;
+    String? termsAndConditionsSaved = S.of(context).loading_terms;
     final termsAndConditionsFuture = fetchTermsAndConditions();
     return FutureBuilder(
       future: termsAndConditionsFuture,
@@ -18,16 +18,14 @@ class TermsAndConditions extends StatelessWidget {
           (BuildContext context, AsyncSnapshot<String> termsAndConditions) {
         if (termsAndConditions.connectionState == ConnectionState.done &&
             termsAndConditions.hasData) {
-          termsAndConditionsSaved = termsAndConditions.data!;
+          termsAndConditionsSaved = termsAndConditions.data;
         }
         return MarkdownBody(
           styleSheet: MarkdownStyleSheet(),
           shrinkWrap: false,
-          data: termsAndConditionsSaved,
+          data: termsAndConditionsSaved!,
           onTapLink: (text, url, title) async {
-            if (await canLaunchUrl(Uri.parse(url!))) {
-              await launchUrl(Uri.parse(url));
-            }
+            await launchUrlWithToast(context, url!);
           },
         );
       },

--- a/uni/lib/view/schedule/widgets/schedule_slot.dart
+++ b/uni/lib/view/schedule/widgets/schedule_slot.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:uni/controller/networking/network_router.dart';
+import 'package:uni/controller/networking/url_launcher.dart';
 import 'package:uni/view/common_widgets/row_container.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 class ScheduleSlot extends StatelessWidget {
   const ScheduleSlot({
@@ -113,9 +113,9 @@ class SubjectButtonWidget extends StatelessWidget {
         'UCURR_GERAL.FICHA_UC_VIEW?pv_ocorrencia_id=$occurrId';
   }
 
-  Future<void> _launchURL() async {
+  Future<void> _launchURL(BuildContext context) async {
     final url = toUcLink(occurrId);
-    await launchUrl(Uri.parse(url));
+    await launchUrlWithToast(context, url);
   }
 
   @override
@@ -133,7 +133,7 @@ class SubjectButtonWidget extends StatelessWidget {
           color: Colors.grey,
           alignment: Alignment.centerRight,
           tooltip: 'Abrir página da UC no browser',
-          onPressed: _launchURL,
+          onPressed: () => _launchURL(context),
         ),
       ],
     );

--- a/uni/lib/view/terms_and_condition_dialog.dart
+++ b/uni/lib/view/terms_and_condition_dialog.dart
@@ -80,7 +80,7 @@ class TermsAndConditionDialog {
                     ),
                   ),
                 ],
-              )
+              ),
             ],
           ),
         );

--- a/uni/lib/view/useful_info/widgets/link_button.dart
+++ b/uni/lib/view/useful_info/widgets/link_button.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:uni/controller/networking/url_launcher.dart';
 
 class LinkButton extends StatelessWidget {
   const LinkButton({
@@ -27,7 +27,7 @@ class LinkButton extends StatelessWidget {
                       .headlineSmall!
                       .copyWith(decoration: TextDecoration.underline),
                 ),
-                onTap: () => launchUrl(Uri.parse(link)),
+                onTap: () => launchUrlWithToast(context, link),
               ),
             )
           ],

--- a/uni/lib/view/useful_info/widgets/text_components.dart
+++ b/uni/lib/view/useful_info/widgets/text_components.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:uni/controller/networking/url_launcher.dart';
 
 Container h1(String text, BuildContext context, {bool initial = false}) {
   final marginTop = initial ? 15.0 : 30.0;
@@ -44,7 +44,7 @@ Container infoText(
               .bodyLarge!
               .apply(color: Theme.of(context).colorScheme.tertiary),
         ),
-        onTap: () => link != '' ? launchUrl(Uri.parse(link)) : null,
+        onTap: () => launchUrlWithToast(context, link),
       ),
     ),
   );


### PR DESCRIPTION
Closes #544 
Method that checks if the user's device can open a link (canLaunchUrl) and displays an toastMessage error if it can't.

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
