### PR TITLE
fix: show correct weekday in exams

### DIFF
--- a/uni/lib/model/entities/exam.dart
+++ b/uni/lib/model/entities/exam.dart
@@ -66,7 +66,7 @@ class Exam {
   String weekDay(AppLocale locale) {
     return DateFormat.EEEE(locale.localeCode.languageCode)
         .dateSymbols
-        .WEEKDAYS[begin.weekday - 1];
+        .WEEKDAYS[begin.weekday % 7];
   }
 
   String month(AppLocale locale) {


### PR DESCRIPTION
This PR changes the weekday selection logic to show the correct weekday for an exam.

The internationalization library we are using returns a list of weekdays from Sunday through Saturday. The weekday property on DateTimes returns a number from 1 (Monday) through 7 (Sunday). This means that `weekday % 7` must be used instead of `weekday - 1`. 

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
