### PR TITLE
fix: handle nullable curricular years

### DIFF
--- a/uni/lib/controller/parsers/parser_course_units.dart
+++ b/uni/lib/controller/parsers/parser_course_units.dart
@@ -84,7 +84,7 @@ List<CourseUnit> parseCourseUnitsAndCourseAverage(
         grade: grade,
         ects: double.tryParse(ects),
         name: name,
-        curricularYear: int.parse(year),
+        curricularYear: int.tryParse(year),
         semesterCode: semester,
       );
       courseUnits.add(courseUnit);


### PR DESCRIPTION
This pull request handles nullable curricular years without throwing exceptions.
I'm not able to test this PR.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [x] Clean, well-structured code
