### PR TITLE
URI.parser(#644)

### DIFF
--- a/uni/lib/controller/parsers/parser_course_units.dart
+++ b/uni/lib/controller/parsers/parser_course_units.dart
@@ -3,8 +3,6 @@ import 'package:html/parser.dart';
 import 'package:http/http.dart' as http;
 import 'package:uni/model/entities/course.dart';
 import 'package:uni/model/entities/course_units/course_unit.dart';
-import 'package:uni/utils/url_parser.dart';
-
 List<CourseUnit> parseCourseUnitsAndCourseAverage(
   http.Response response,
   Course course, {
@@ -48,9 +46,9 @@ List<CourseUnit> parseCourseUnitsAndCourseAverage(
 
     final year = row.children[0].innerHtml;
     final semester = row.children[1].innerHtml;
-    final occurId = getUrlQueryParameters(
+    final occurId = Uri.parse(
       row.children[2].firstChild!.attributes['href']!,
-    )['pv_ocorrencia_id']!;
+    ).queryParameters['pv_ocorrencia_id']!;
     final codeName = row.children[2].children[0].innerHtml;
     final name = row.children[3].children[0].innerHtml;
     final ects = row.children[5].innerHtml.replaceAll(',', '.');

--- a/uni/lib/controller/parsers/parser_courses.dart
+++ b/uni/lib/controller/parsers/parser_courses.dart
@@ -1,7 +1,6 @@
 import 'package:html/parser.dart' show parse;
 import 'package:http/http.dart' as http;
 import 'package:uni/model/entities/course.dart';
-import 'package:uni/utils/url_parser.dart';
 
 List<Course> parseMultipleCourses(List<http.Response> responses) {
   final courses = <Course>[];
@@ -27,7 +26,7 @@ List<Course> _parseCourses(http.Response response) {
     final courseUrl = div
         .querySelector('.estudante-lista-curso-nome > a')
         ?.attributes['href'];
-    final courseId = getUrlQueryParameters(courseUrl ?? '')['pv_curso_id'];
+    final courseId = Uri.parse(courseUrl ?? '').queryParameters['pv_curso_id'];
     final courseState = div.querySelectorAll('.formulario td')[3].text;
     final courseFestId = div
         .querySelector('.estudante-lista-curso-detalhes > a')
@@ -54,15 +53,15 @@ List<Course> _parseCourses(http.Response response) {
     final div = oldCourses[i];
     final courseName = div.children[0].firstChild?.text?.trim();
     final courseUrl = div.querySelector('a')?.attributes['href'];
-    final courseId = getUrlQueryParameters(courseUrl ?? '')['pv_curso_id'];
+    final courseId = Uri.parse(courseUrl ?? '').queryParameters['pv_curso_id'];
     var courseFirstEnrollment = div.children[4].text;
     courseFirstEnrollment = courseFirstEnrollment
         .substring(0, courseFirstEnrollment.indexOf('/'))
         .trim();
     final courseState = div.children[5].text;
-    final courseFestId = getUrlQueryParameters(
+    final courseFestId = Uri.parse(
       div.children[6].firstChild?.attributes['href'] ?? '',
-    )['pv_fest_id'];
+    ).queryParameters['pv_fest_id'];
     courses.add(
       Course(
         firstEnrollment: int.parse(courseFirstEnrollment),


### PR DESCRIPTION
Closes #644 
Replace the local `url_parser` file with the usage of `Uri.parse` and `queryParameters`.

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
