### PR TITLE
Fix Parser for different faculties 

### DIFF
--- a/uni/lib/controller/fetchers/exam_fetcher.dart
+++ b/uni/lib/controller/fetchers/exam_fetcher.dart
@@ -55,7 +55,6 @@ class ExamFetcher implements SessionDependantFetcher {
         }
       }
     }
-
     return exams.toList();
   }
 }

--- a/uni/lib/controller/parsers/parser_exams.dart
+++ b/uni/lib/controller/parsers/parser_exams.dart
@@ -58,7 +58,7 @@ class ParserExams {
                     .map((e) => e.trim())
                     .toList();
               }
-              schedule = examsDay.text.endsWith('0:00-')
+              schedule = examsDay.text.endsWith('-')
                   ? '00:00-00:00'
                   : examsDay.text.substring(
                       examsDay.text.indexOf(':') - 2,

--- a/uni/lib/controller/parsers/parser_exams.dart
+++ b/uni/lib/controller/parsers/parser_exams.dart
@@ -27,7 +27,6 @@ class ParserExams {
     final examTypes = <String>[];
     var rooms = <String>[];
     String? subject;
-    String? schedule;
     var id = '0';
     var days = 0;
     var tableNum = 0;
@@ -58,17 +57,17 @@ class ParserExams {
                     .map((e) => e.trim())
                     .toList();
               }
-              schedule = examsDay.text.endsWith('-')
-                  ? '00:00-00:00'
-                  : examsDay.text.substring(
-                      examsDay.text.indexOf(':') - 2,
-                      examsDay.text.indexOf(':') + 9,
-                    );
-              final splittedSchedule = schedule!.split('-');
-              final begin =
-                  DateTime.parse('${dates[days]} ${splittedSchedule[0]}');
-              final end =
-                  DateTime.parse('${dates[days]} ${splittedSchedule[1]}');
+              final DateTime begin;
+              final DateTime end;
+              if (!examsDay.text.endsWith('-')) {
+                final rx = RegExp(r'(\d{2}:\d{2})-(\d{2}:\d{2})');
+                final match = rx.allMatches(examsDay.text).first;
+                begin = DateTime.parse('${dates[days]} ${match.group(1)!}');
+                end = DateTime.parse('${dates[days]} ${match.group(2)!}');
+              } else {
+                begin = DateTime.parse('${dates[days]} 00:00');
+                end = DateTime.parse('${dates[days]} 00:00');
+              }
               final exam = Exam(
                 id,
                 begin,

--- a/uni/lib/controller/parsers/parser_exams.dart
+++ b/uni/lib/controller/parsers/parser_exams.dart
@@ -51,13 +51,19 @@ class ParserExams {
                     .queryParameters['p_exa_id']!;
               }
               if (examsDay.querySelector('span.exame-sala') != null) {
-                rooms =
-                    examsDay.querySelector('span.exame-sala')!.text.split(',');
+                rooms = examsDay
+                    .querySelector('span.exame-sala')!
+                    .text
+                    .split(',')
+                    .map((e) => e.trim())
+                    .toList();
               }
-              schedule = examsDay.text.substring(
-                examsDay.text.indexOf(':') - 2,
-                examsDay.text.indexOf(':') + 9,
-              );
+              schedule = examsDay.text.endsWith('0:00-')
+                  ? '00:00-00:00'
+                  : examsDay.text.substring(
+                      examsDay.text.indexOf(':') - 2,
+                      examsDay.text.indexOf(':') + 9,
+                    );
               final splittedSchedule = schedule!.split('-');
               final begin =
                   DateTime.parse('${dates[days]} ${splittedSchedule[0]}');
@@ -72,7 +78,6 @@ class ParserExams {
                 examTypes[tableNum],
                 course.faculty!,
               );
-
               examsList.add(exam);
             });
           }

--- a/uni/lib/model/entities/exam.dart
+++ b/uni/lib/model/entities/exam.dart
@@ -83,7 +83,7 @@ class Exam {
 
   @override
   String toString() {
-    return '''$id - $subject - ${begin.year} - $month - ${begin.day} -  $beginTime-$endTime - $type - $rooms - $weekDay''';
+    return '''$id - $subject - ${begin.year} - $month - ${begin.day} - $beginTime-$endTime - $type - $rooms - $weekDay''';
   }
 
   @override

--- a/uni/lib/view/exams/exams.dart
+++ b/uni/lib/view/exams/exams.dart
@@ -35,18 +35,20 @@ class ExamsPageViewState extends GeneralPageViewState<ExamsPageView> {
           }),
         ),
         LazyConsumer<ExamProvider, List<Exam>>(
-          builder: (context, exams) => Column(
-            children: createExamsColumn(
-              context,
-              exams
-                  .where(
-                    (exam) =>
-                        filteredExamTypes[Exam.getExamTypeLong(exam.type)] ??
-                        true,
-                  )
-                  .toList(),
-            ),
-          ),
+          builder: (context, exams) {
+            return Column(
+              children: createExamsColumn(
+                context,
+                exams
+                    .where(
+                      (exam) =>
+                          filteredExamTypes[Exam.getExamTypeLong(exam.type)] ??
+                          true,
+                    )
+                    .toList(),
+              ),
+            );
+          },
           hasContent: (exams) => exams.isNotEmpty,
           onNullContent: Center(
             heightFactor: 1.2,

--- a/uni/lib/view/exams/widgets/exam_row.dart
+++ b/uni/lib/view/exams/widgets/exam_row.dart
@@ -54,11 +54,13 @@ class _ExamRowState extends State<ExamRow> {
                 children: <Widget>[
                   Column(
                     mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      ExamTime(
-                        begin: widget.exam.beginTime,
-                      ),
-                    ],
+                    children: widget.exam.beginTime != '00:00'
+                        ? [
+                            ExamTime(
+                              begin: widget.exam.beginTime,
+                            ),
+                          ]
+                        : [],
                   ),
                   ExamTitle(
                     subject: widget.exam.subject,

--- a/uni/test/integration/resources/exam2_example.html
+++ b/uni/test/integration/resources/exam2_example.html
@@ -1,0 +1,489 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="pt" dir="ltr">
+<head>
+<link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png" /><link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png" /><link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png" /><link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png" /><link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png" /><link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png" /><link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png" /><link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png" /><link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" /><link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" /><link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" /><link rel="icon" type="image/png" href="/favicon-160x160.png" sizes="160x160" /><meta name="msapplication-TileColor" content="#000000" /><meta name="msapplication-TileImage" content="/mstile-144x144.png" /><meta name="msapplication-square70x70logo" content="/mstile-70x70.png" /><meta name="msapplication-square150x150logo" content="/mstile-150x150.png" /><meta name="msapplication-square310x310logo" content="/mstile-310x310.png" />
+<meta name="viewport" content="width=device-width">
+<meta http-equiv="Content-Type" content="text/html;charset=iso-8859-15">
+<link rel="canonical" href="https://sigarra.up.pt/fcup/pt/exa_geral.mapa_de_exames?p_curso_id=23141" />
+<meta name="author" content="Faculdade de Ciências da Universidade do Porto">
+<!--start css -->
+<link rel="stylesheet" type="text/css" href="/fcup/pt/css/10562" media="screen,print">
+<link rel="stylesheet" type="text/css" href="/fcup/pt/css/10882" media="screen,print">
+<link rel="stylesheet" type="text/css" href="/fcup/pt/css/10579" media="screen,print">
+<link rel="stylesheet" type="text/css" href="/fcup/pt/css/10580" media="print">
+<link rel="stylesheet" type="text/css" href="/fcup/pt/css/10577" media="screen,print">
+<link rel="stylesheet" type="text/css" href="/fcup/pt/css/11482" media="screen,print">
+<link rel="stylesheet" type="text/css" href="/fcup/pt/css/10612" media="screen,print">
+<link rel="stylesheet" type="text/css" href="/fcup/pt/css/10609" media="print">
+<link rel="stylesheet" type="text/css" href="/fcup/pt/css/10805" media="screen,print,handheld">
+<link rel="stylesheet" type="text/css" href="/fcup/pt/css/11922" media="screen,print,handheld">
+<link rel="stylesheet" type="text/css" href="/fcup/pt/css/11942" media="screen,print,handheld">
+<link rel="stylesheet" type="text/css" href="/fcup/pt/css/11962" media="print">
+
+<!--end css -->
+<title>FCUP - Mapa de Exames</title>
+
+<script type="text/javascript" src="js/web_base.js"></script>
+
+<script type="text/javascript" src="/fcup/pt/js/jquery.js"></script>
+<script type="text/javascript" src="/fcup/pt/js/jquery-migrate.js"></script>
+<script type="text/javascript" src="/fcup/pt/js/bootstrap.min.js"></script>
+
+
+</head>
+<body >
+<div class="saltar" tabindex="0">Saltar para:<ul><li><a href="#ancora-conteudo" accesskey="c">Conteúdo (tecla de atalho: c)</a></li><li><a href="#ancora-opcoes" accesskey="o">Opções (tecla de atalho: o)</a></li><li><a href="#ancora-atalhos" accesskey="a">Atalhos (tecla de atalho: a)</a></li><li><a href="#ancora-menu" accesskey="m">Menu Principal (tecla de atalho: m)</a></li><li><a href="#ancora-login" accesskey="s">Terminar sessão autenticada (tecla de atalho: s)</a></li></ul></div>
+<div id="involucro">
+<div id="cabecalho">
+<a href="web_page.Inicial" title="Ligação à página Inicial"><img src="/fcup/pt/imagens/LogotipoSI" alt="Logótipo"  title="Logótipo"   id="logotipo" width="400" height="160"></a>
+<link rel="stylesheet" href="/lib/bootstrap/css/bootstrap.min.css">
+<script type="text/javascript" src="/lib/bootstrap/js/bootstrap.min.js"></script>
+
+<link rel="stylesheet" href="/lib/font-awesome/css/font-awesome.min.css"><a href="#" data-element-to-toggle="#colunaprincipal" id="toggle-coluna-principal" aria-hidden="true">
+  <div class="visibilidade-coluna-esquerda">
+    <span class="fa fa-bars" aria-hidden="true"></span>
+    <span class="acs">Comuta visibilidade da coluna esquerda</span>
+  </div>
+</a><div id="cabecalho-conteudo-1">
+<div class="logotipo-alternativo" aria-hidden="true">
+  <a href="web_page.Inicial" title="Ligação à página Inicial"><img src="imagens/LogotipoSI" alt="Logótipo" title="Logótipo" id="logotipo" width="200" height="80"></a>
+</div></div><div id="cabecalho-conteudo-2">
+<img src="/fcup/pt/imagens/DestaqueBranco" class="destaque" alt="FCUP"><div class="cabecalho-agregador"><span class="idioma en" title="This page is not available in English">
+English
+</span>
+<a href="web_base.gera_pagina?p_pagina=1004483" class="ajuda-contextual" title="Ajuda Contextual">
+ajuda
+</a>
+<div class="autenticacao autenticado">
+<a href="vld_validacao.sair?p_address=EXA_GERAL.MAPA_DE_EXAMES?p_curso_id=23141" title="Terminar sessão BDMENDES" class="terminar-sessao"><span>Terminar sessão</span></a>
+<a href="vld_entidades_geral.entidade_pagina?pct_id=2095894" title="Página de BDMENDES" class="nome">BDMENDES</a>
+<a href="vld_entidades_geral.entidade_pagina?pct_id=2095894" title="Fotografia de BDMENDES" class="fotografia">
+<img src="fotografias_service.foto_thumb?pct_cod=202107940"></a>
+</a>
+</div>
+</div><a href="#" data-element-to-toggle="#colunaextra" id="toggle-coluna-secundaria" aria-hidden="true">
+  <div class="visibilidade-coluna-direita">
+    <span class="fa fa-ellipsis-v" aria-hidden="true"></span>
+    <span class="acs">Comuta visibilidade da coluna direita</span>
+  </div>
+</a></div>
+</div>
+<div id="barralocalizacao"><strong>Você está em:</strong> <a href="web_page.inicial" title="Início" >Início</a> &gt; <a href="cur_geral.cur_inicio" title="Cursos/CE" >Cursos/CE</a> &gt; <a href="exa_geral.chamadas_list?p_curso_id=23141" title="Chamadas" >Chamadas</a><span class="pagina-atual"> &gt; Exames</span></div>
+<div id="envolvente">
+<div id="colunaprincipal"><!-- Inicio Coluna Principal -->
+<script>
+$(function() {
+var mytemp=  $("div#caixa-validacao").detach();
+mytemp.insertAfter('div#caixa-campus');
+});
+</script>
+<nav><div id="menu-navegacao">
+<div id="menu-navegacao-cabecalho">Menu Principal</div>
+<div id="menu-navegacao-conteudo"><a name="ancora-menu" class="ecra"></a>
+<ul>
+<li><a href="" title="   " class="menu-navegacao-conteudo-0">   </a></li>
+<li><a href="" title="A FCUP" class="menu-navegacao-conteudo-101">A FCUP</a></li>
+<li><a href="WEB_BASE.GERA_PAGINA?P_pagina=1182" title="Apresentação" class="menu-navegacao-conteudo-102">Apresentação</a></li>
+<li><a href="web_base.gera_pagina?p_pagina=1050315" title="História e Património" class="menu-navegacao-conteudo-103">História e Património</a></li>
+<li><a href="web_base.gera_pagina?p_pagina=1006007" title="Órgãos de Gestão" class="menu-navegacao-conteudo-104">Órgãos de Gestão</a></li>
+<li><a href="uni_geral.nivel_list?pv_nivel_id=1" title="Departamentos" class="menu-navegacao-conteudo-105">Departamentos</a></li>
+<li><a href="uni_geral.nivel_list?pv_nivel_id=11" title="Serviços" class="menu-navegacao-conteudo-106">Serviços</a></li>
+<li><a href="" title="ENSINO" class="menu-navegacao-conteudo-108">ENSINO</a></li>
+<li><a href="cur_geral.cur_inicio" title="Cursos" class="menu-navegacao-conteudo-109-selected">Cursos</a></li>
+<li><a href="web_base.gera_pagina?p_pagina=1170" title="Estudantes" class="menu-navegacao-conteudo-110">Estudantes</a></li>
+<li><a href="WEB_BASE.GERA_PAGINA?P_pagina=1051455" title="Candidaturas" class="menu-navegacao-conteudo-111">Candidaturas</a></li>
+<li><a href="WEB_BASE.GERA_PAGINA?p_pagina=1052115" title="Matrículas" class="menu-navegacao-conteudo-112">Matrículas</a></li>
+<li><a href="" title="INVESTIGAÇÃO" class="menu-navegacao-conteudo-113">INVESTIGAÇÃO</a></li>
+<li><a href="WEB_BASE.GERA_PAGINA?p_pagina=1827" title="Unidades" class="menu-navegacao-conteudo-114">Unidades</a></li>
+<li><a href="projectos_geral.pesquisa_projectos" title="Projetos" class="menu-navegacao-conteudo-115">Projetos</a></li>
+<li><a href="" title="COMUNIDADE" class="menu-navegacao-conteudo-116">COMUNIDADE</a></li>
+<li><a href="WEB_BASE.GERA_PAGINA?P_pagina=1050295" title="Alumni" class="menu-navegacao-conteudo-117">Alumni</a></li>
+<li><a href="WEB_BASE.GERA_PAGINA?P_pagina=1050296" title="Escolas" class="menu-navegacao-conteudo-118">Escolas</a></li>
+<li><a href="noticias_geral.ver_noticia?p_nr=59013" title="Empregabilidade" class="menu-navegacao-conteudo-119">Empregabilidade</a></li>
+<li><a href="web_base.gera_pagina?p_pagina=1823" title="Internacional" class="menu-navegacao-conteudo-120">Internacional</a></li>
+<li><a href="web_base.gera_pagina?p_pagina=1017569" title="Serviços Exterior" class="menu-navegacao-conteudo-121">Serviços Exterior</a></li>
+<li><a href="web_base.gera_pagina?p_pagina=1831" title="Pesquisa" class="menu-navegacao-conteudo-122">Pesquisa</a></li>
+</ul></div></div></nav> <!-- end navegacao-menu -->
+<div id="caixa-campus">
+<div id="caixa-campus-cabecalho">
+Mapa das Instalações
+</div>
+<div id="caixa-campus-conteudo">
+<div class="planta-involucro">
+<map name="mapaypXfCwJT"><area shape="poly" alt="FC6 - Departamento de Ciência de Computadores" coords="15,40,30,40,30,53,15,53" href="instal_geral.edificio_view?pv_id=1332" title="FC6 - Departamento de Ciência de Computadores" />
+<area shape="poly" alt="FC5 - Edifício Central" coords="55,34,63,37,63,43,54,43" href="instal_geral.edificio_view?pv_id=1331" title="FC5 - Edifício Central" />
+<area shape="poly" alt="FC4 - Departamento de Biologia" coords="51,43,61,44,60,53,50,53," href="instal_geral.edificio_view?pv_id=1325" title="FC4 - Departamento de Biologia" />
+<area shape="poly" alt="FC3 - Departamento de Física e Astronomia e Departamento GAOT" coords="64,48,78,48,78,55,65,55" href="instal_geral.edificio_view?pv_id=1330" title="FC3 - Departamento de Física e Astronomia e Departamento GAOT" />
+<area shape="poly" alt="FC2 - Departamento de Química e Bioquímica" coords="70,57,83,57,83,64,70,64" href="instal_geral.edificio_view?pv_id=1321" title="FC2 - Departamento de Química e Bioquímica" />
+<area shape="poly" alt="FC1 - Departamento de Matemática" coords="84,53,97,53,97,59,94,59,94,63,88,63,88,59,84,58" href="instal_geral.edificio_view?pv_id=1323" title="FC1 - Departamento de Matemática" /></map>
+<img src="instal_geral2.get_mapa?pv_id=72322" usemap="#mapaypXfCwJT">
+</div>
+</div>
+</div>
+<!--Fim do Mapa das Instalações-->
+</div><!-- end colunaprincipal -->
+<div id="colunaextra"><!-- Início da Coluna Extra -->
+<div id="caixa-atalhos">
+<div id="caixa-atalhos-cabecalho">Atalhos</div>
+<div id="caixa-atalhos-conteudo">
+<a name="ancora-atalhos"></a>
+<ul id="caixa-atalhos-conteudo-ul">
+<li id="caixa-atalhos-conteudo-portal"><a href="atalhos.lista" class="opcaoatalho">Ver Lista</a></li>
+</ul>
+<script type="text/javascript">
+add_atalho(1014679,"p_curso_id=23141","Mapa de Exames","Adicionar Página");
+</script>
+</div><!-- end caixa-atalhos-conteudo --></div><!-- end caixa-atalhos -->
+<a name="ancora-opcoes" class="ecra"></a>
+<div class="caixa-opcoes">
+<div class="caixa-opcoes-cabecalho opc-grupo-10">Opções</div>
+<div class="caixa-opcoes-conteudo">
+<ul>
+<li><a href="exa_geral.mapa_de_exames?p_layout=0&p_pfunc_id=&pv_estud_num=&p_espaco_id=&p_ano_lectivo=&p_ocorr_id=&p_curso_id=23141 " title="Versão de Impressão">Versão de Impressão</a></li>
+</ul><!--fecha_grupo_anterior-->
+</div><!-- end caixa-opcoes-conteudo -->
+</div><!-- end caixa-opcoes -->
+</div><!-- end Coluna Extra -->
+<div id="conteudo"><div id="conteudoinner">
+<h1 id="seccao">Cursos</h1>
+<a name="ancora-conteudo" class="ecra"></a>
+<h1>Mapa de Exames</h1>
+<h2>L:EF</h2>
+<h3>Normal - Época Normal (2ºS)</h3>
+<table >
+<tr><td>
+<table  class="dados ">
+<tr>
+<th width="15%">Segunda<br><span class="exame-data">2099-05-29</span></th>
+<th width="15%">Terça<br><span class="exame-data">2099-05-30</span></th>
+<th width="15%">Quarta<br><span class="exame-data">2099-05-31</span></th>
+<th width="15%">Quinta<br><span class="exame-data">2099-06-01</span></th>
+<th width="15%">Sexta<br><span class="exame-data">2099-06-02</span></th>
+<th width="15%">Sábado<br><span class="exame-data">2099-06-03</span></th>
+</tr>
+<tr>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34009" title="Sinais e Sistemas" ><b>FIS2019</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+<p>
+<table  class="dadossz">
+<tr>
+<th width="15%">Segunda<br><span class="exame-data">2099-06-05</span></th>
+<th width="15%">Terça<br><span class="exame-data">2099-06-06</span></th>
+<th width="15%">Quarta<br><span class="exame-data">2099-06-07</span></th>
+<th width="15%">Quinta<br><span class="exame-data">2099-06-08</span></th>
+<th width="15%">Sexta<br><span class="exame-data">2099-06-09</span></th>
+<th width="15%">Sábado<br><span class="exame-data">2099-06-10</span></th>
+</tr>
+<tr>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=33994" title="Física da Matéria Condensada" ><b>FIS3020</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34085" title="Fundamentos de Química" ><b>Q1004</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=33997" title="Física Moderna" ><b>FIS2017</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=33999" title="Métodos Computacionais em Engenharia" ><b>FIS3022</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=33983" title="Programação II" ><b>CCINF1002</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top"><p></td>
+</tr>
+</table>
+<p>
+<table  class="dadossz">
+<tr>
+<th width="15%">Segunda<br><span class="exame-data">2099-06-12</span></th>
+<th width="15%">Terça<br><span class="exame-data">2099-06-13</span></th>
+<th width="15%">Quarta<br><span class="exame-data">2099-06-14</span></th>
+<th width="15%">Quinta<br><span class="exame-data">2099-06-15</span></th>
+<th width="15%">Sexta<br><span class="exame-data">2099-06-16</span></th>
+<th width="15%">Sábado<br><span class="exame-data">2099-06-17</span></th>
+</tr>
+<tr>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34000" title="Física Computacional" ><b>FIS2018</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34003" title="Eletromagnetismo I" ><b>FIS1014</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34053" title="Probabilidade e Estatística" ><b>M2030</b></a><br>09:30-12:30<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"><a href="instal_geral.espaco_view?pv_id=68617" title="FC1122 (Abre numa nova janela)" target="_blank" >FC1122</a>, <a href="instal_geral.espaco_view?pv_id=68573" title="FC1219 (Abre numa nova janela)" target="_blank" >FC1219</a></span></td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+<p>
+<table  class="dadossz">
+<tr>
+<th width="15%">Segunda<br><span class="exame-data">2099-06-19</span></th>
+<th width="15%">Terça<br><span class="exame-data">2099-06-20</span></th>
+<th width="15%">Quarta<br><span class="exame-data">2099-06-21</span></th>
+<th width="15%">Quinta<br><span class="exame-data">2099-06-22</span></th>
+<th width="15%">Sexta<br><span class="exame-data">2099-06-23</span></th>
+<th width="15%">Sábado<br><span class="exame-data">2099-06-24</span></th>
+</tr>
+<tr>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34075" title="Análise II" ><b>M1015</b></a><br>09:00-12:00<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"><a href="instal_geral.espaco_view?pv_id=68608" title="FC1120 (Abre numa nova janela)" target="_blank" >FC1120</a>, <a href="instal_geral.espaco_view?pv_id=68617" title="FC1122 (Abre numa nova janela)" target="_blank" >FC1122</a>, <a href="instal_geral.espaco_view?pv_id=68573" title="FC1219 (Abre numa nova janela)" target="_blank" >FC1219</a>, <a href="instal_geral.espaco_view?pv_id=68569" title="FC1226 (Abre numa nova janela)" target="_blank" >FC1226</a></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top"><p></td>
+</table>
+</td></tr>
+</table>
+<h3>Recurso - Época Recurso (2ºS)</h3>
+<table >
+<tr><td>
+<table  class="dados ">
+<tr>
+<th width="15%">Segunda<br><span class="exame-data">2099-06-26</span></th>
+<th width="15%">Terça<br><span class="exame-data">2099-06-27</span></th>
+<th width="15%">Quarta<br><span class="exame-data">2099-06-28</span></th>
+<th width="15%">Quinta<br><span class="exame-data">2099-06-29</span></th>
+<th width="15%">Sexta<br><span class="exame-data">2099-06-30</span></th>
+<th width="15%">Sábado<br><span class="exame-data">2099-07-01</span></th>
+</tr>
+<tr>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34109" title="Programação II" ><b>CCINF1002</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34173" title="Sinais e Sistemas" ><b>FIS2019</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34122" title="Métodos Computacionais em Engenharia" ><b>FIS3022</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34136" title="Laboratório de Física I" ><b>FIS1018</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34106" title="Probabilidade e Estatística" ><b>M2030</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34157" title="Análise II" ><b>M1015</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top"><p></td>
+</tr>
+</table>
+<p>
+<table  class="dadossz">
+<tr>
+<th width="15%">Segunda<br><span class="exame-data">2099-07-03</span></th>
+<th width="15%">Terça<br><span class="exame-data">2099-07-04</span></th>
+<th width="15%">Quarta<br><span class="exame-data">2099-07-05</span></th>
+<th width="15%">Quinta<br><span class="exame-data">2099-07-06</span></th>
+<th width="15%">Sexta<br><span class="exame-data">2099-07-07</span></th>
+<th width="15%">Sábado<br><span class="exame-data">2099-07-08</span></th>
+</tr>
+<tr>
+<td class="l k" valign="top"><p></td>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34206" title="Eletromagnetismo I" ><b>FIS1014</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34221" title="Física Computacional" ><b>FIS2018</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34234" title="Física da Matéria Condensada" ><b>FIS3020</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top">
+<table  class="dados mapa">
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34248" title="Física Moderna" ><b>FIS2017</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+<tr class="d">
+<td class="l exame"><a href="exa_geral.exame_view?p_exa_id=34250" title="Fundamentos de Química" ><b>Q1004</b></a><br>0:00-<br><img src="/fcup/pt/imagens/Spacer" alt=""  title=""   class="border0" height="6"><br><span class="exame-sala"></span></td>
+</tr>
+</table>
+</td>
+<td class="l k" valign="top"><p></td>
+</table>
+</td></tr>
+</table>
+</div><!-- end conteudoinner--></div><!-- end conteudo-->
+</div><!-- end envolvente -->
+<div class="limpar"></div>
+<div id="ferramentas">
+<span id="imprimir-extra"><script type="text/javascript">
+//<![CDATA[document.write('<a href="javascript:window.print()">Versão para Impressão<\/a>')
+//]]>
+</script></span>
+<span id="recomendar"><a href="mailto:?subject=Penso%20que%20isto%20te%20pode%20interessar:%20FCUP%20-%20Mapa%20de%20Exames&amp;body=Penso%20que%20isto%20te%20pode%20interessar:%20FCUP%20-%20Mapa%20de%20Exames.%20%250A%250Ahttp://sigarra.up.pt/fcup/pt/EXA_GERAL.MAPA_DE_EXAMES?p_curso_id=23141">Recomendar Página</a></span>
+<script type="text/javascript">
+document.write('<span id="favoritos"><a href = "javascript:AddToFavorites()" title="Adicionar aos Favoritos">Adicionar aos Favoritos<\/a><\/span>');
+</script>
+<span id="voltar-topo">
+<a href="#conteudo">Voltar ao Topo</a></span></div><!-- end ferramentas -->
+<div id="rodape">
+
+<span id="rodape-copyright"><a href="web_base.gera_pagina?p_pagina=COPYRIGHT">Copyright 1996-2099 &copy; Faculdade de Ciências da Universidade do Porto</a></span>
+<span id="rodape-termos">&nbsp;I&nbsp;<a href="web_base.gera_pagina?p_pagina=TERMOS%20E%20CONDICOES">Termos e Condições</a></span>
+<span id="rodape-acessibilidade">&nbsp;I&nbsp;<a href="web_base.gera_pagina?p_pagina=ACESSIBILIDADE">Acessibilidade</a></span>
+<span id="rodape-az">&nbsp;I&nbsp;<a href="az_geral.az?pct_id=162">Índice A-Z</a></span>
+<span id="rodape-livro-visitas">&nbsp;I&nbsp;<a href="livro_visitas_geral.ver">Livro de Visitas</a></span>
+<br>
+<span id="rodape-geracao">Página gerada em: 2099-04-28 às 16:13:57</span>
+
+| <span id="rodape-pua"><a href="https://sigarra.up.pt/up/pt/web_base.gera_pagina?p_pagina=politica-utilizacao-aceitavel" title="Ligação ao Site da U.Porto">Política de Utilização Aceitável</a></span> | <span id="rodape-pd"><a href="https://sigarra.up.pt/up/pt/web_base.gera_pagina?p_pagina=politica-protecao-dados-pessoais" title="Ligação ao Site da U.Porto">Política de Proteção de Dados Pessoais</a> | <a href="https://up.pt/denuncias" title="Ligação ao Portal da Denúncia U.Porto">Denúncias</a></span>
+<br><br><script type="text/javascript">
+$(function() {
+    /*function setHeights() {
+        var uiReferencia = null,
+            uiElementos = $("#colunaprincipal, #colunaextra, #conteudo-extra, #conteudo-principal, #conteudo");
+
+        $("#conteudo").css({height: "auto"});
+        uiElementos.each(function(index, elemento) {
+            var uiElemento = $(elemento);
+
+            if (!uiReferencia || uiElemento.outerHeight() > uiReferencia.outerHeight()) {
+                uiReferencia = uiElemento;
+            }
+        });
+
+        uiElementos.each(function(index, elemento) {
+            var uiElemento = $(elemento);
+
+            uiElemento.height(uiElemento.height() + (uiReferencia.outerHeight() - uiElemento.outerHeight()));
+        });
+    }
+
+    setTimeout(setHeights, 300);*/
+<
+$("*[data-element-to-toggle]").on("click", function(event) {
+   event.preventDefault();
+   $($(this).attr("data-element-to-toggle")).toggle();
+});
+
+/*$(window).on("resize", function (event) {
+   setTimeout(setHeights, 300);
+   $("[data-element-to-toggle]").each(function(index, elemento) {
+      var uiElemento = $(elemento);
+      if (!uiElemento.find("> div").is(":visible")) {
+         $(uiElemento.attr("data-element-to-toggle")).css({"display": ""});
+      }
+   });
+});*/
+})
+</script></div><!-- end rodape -->
+</div><!-- end involucro -->
+<!-- Powered by GESSI: (c) 1996-2099 Universidade do Porto (Portugal) -->
+<!-- Piwik -->
+<script type="text/javascript">
+	var siteIdsArr = [13,5],
+		pkBaseURL = (("https:" == document.location.protocol) ? "https://piwik.up.pt/" : "http://piwik.up.pt/"),
+        oBody = document.getElementsByTagName('body')[0],
+        oScript = document.createElement('script');
+    
+    function onLibLoaded() {
+        try {
+            for (var i = 0; i < siteIdsArr.length; i++) {
+                var piwikTracker = Piwik.getTracker(pkBaseURL + "piwik.php", siteIdsArr[i]);
+                piwikTracker.trackPageView();
+                piwikTracker.enableLinkTracking();
+            }
+        } catch( err ) { console.log(err);}
+    }
+        
+    oScript.type = 'text/javascript';
+    oScript.src = pkBaseURL + "piwik.js";
+    // most browsers
+    oScript.onload = onLibLoaded;
+    // IE 6 & 7
+    oScript.onreadystatechange = function() {
+        if (this.readyState == 'complete') {
+            onLibLoaded();
+        }
+    }
+    oBody.appendChild(oScript);
+</script>
+<noscript>
+<p>
+<img src="https:///piwik.php?idsite=13" style="border:0" alt="" />
+</p>
+</noscript>
+<!-- End Piwik Tracking Code -->
+</body>
+</html>

--- a/uni/test/integration/src/exams2_page_test.dart
+++ b/uni/test/integration/src/exams2_page_test.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+import 'package:uni/controller/networking/network_router.dart';
+import 'package:uni/controller/parsers/parser_exams.dart';
+import 'package:uni/model/entities/course.dart';
+import 'package:uni/model/entities/course_units/course_unit.dart';
+import 'package:uni/model/entities/exam.dart';
+import 'package:uni/model/entities/profile.dart';
+import 'package:uni/model/entities/session.dart';
+import 'package:uni/model/providers/lazy/exam_provider.dart';
+import 'package:uni/view/exams/exams.dart';
+
+import '../../mocks/integration/src/exams_page_test.mocks.dart';
+import '../../test_widget.dart';
+
+@GenerateNiceMocks([MockSpec<http.Client>(), MockSpec<http.Response>()])
+void main() async {
+  await initTestEnvironment();
+
+  group('ExamsPage Second Integration Tests', () {
+    final mockClient = MockClient();
+    final mockResponse = MockResponse();
+    final fis3022CourseUnit = CourseUnit(
+      abbreviation: 'FIS3022',
+      name: 'Métodos Computacionais em Engenharia',
+      occurrId: 0,
+      status: 'V',
+    );
+    final m2030CourseUnit = CourseUnit(
+      abbreviation: 'M2030',
+      name: 'Probabilidade e Estatística',
+      occurrId: 0,
+      status: 'V',
+    );
+
+    final beginFis3022Exam = DateTime.parse('2099-06-09 00:00');
+    final endFis3022Exam = DateTime.parse('2099-06-09 00:00');
+    final fis3022Exam = Exam(
+      '33999',
+      beginFis3022Exam,
+      endFis3022Exam,
+      'FIS3022',
+      [],
+      'EN',
+      'fcup',
+    );
+    final beginM2030Exam = DateTime.parse('2099-06-17 09:30');
+    final endM2030Exam = DateTime.parse('2099-06-17 12:30');
+    final m2030Exam = Exam(
+      '34053',
+      beginM2030Exam,
+      endM2030Exam,
+      'M2030',
+      ['FC1122', 'FC1219'],
+      'EN',
+      'fcup',
+    );
+    final beginQ1004Exam = DateTime.parse('2099-06-07 00:00');
+    final endQ1004Exam = DateTime.parse('2099-06-07 00:00');
+    final q1004Exam =
+        Exam('34085', beginQ1004Exam, endQ1004Exam, 'Q1004', [], 'EN', 'fcup');
+
+    final filteredExams = <String, bool>{};
+    for (final type in Exam.displayedTypes) {
+      filteredExams[type] = true;
+    }
+
+    final profile = Profile()..courses = [Course(id: 9113, faculty: 'fcup')];
+
+    testWidgets('Exams', (WidgetTester tester) async {
+      NetworkRouter.httpClient = mockClient;
+      final mockHtml = File('test/integration/resources/exam2_example.html')
+          .readAsStringSync(encoding: latin1);
+      when(mockResponse.body).thenReturn(mockHtml);
+      when(mockResponse.statusCode).thenReturn(200);
+      when(mockClient.get(any, headers: anyNamed('headers')))
+          .thenAnswer((_) async => mockResponse);
+
+      final examProvider = ExamProvider();
+
+      const widget = ExamsPageView();
+
+      final providers = [
+        ChangeNotifierProvider(create: (_) => examProvider),
+      ];
+      await tester.pumpWidget(testableWidget(widget, providers: providers));
+
+      expect(find.byKey(Key('$fis3022Exam-exam')), findsNothing);
+      expect(find.byKey(Key('$m2030Exam-exam')), findsNothing);
+      expect(find.byKey(Key('$q1004Exam-exam')), findsNothing);
+
+      final exams = await examProvider.fetchUserExams(
+        ParserExams(),
+        profile,
+        Session(username: '', cookies: '', faculties: ['fcup']),
+        [fis3022CourseUnit, m2030CourseUnit],
+        persistentSession: false,
+      );
+
+      examProvider.setState(exams);
+
+      expect(examProvider.state!.contains(fis3022Exam), true);
+      expect(examProvider.state!.contains(m2030Exam), true);
+
+      // print(exams);
+
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(Key('$fis3022Exam-exam')), findsOneWidget);
+      expect(find.byKey(Key('$m2030Exam-exam')), findsOneWidget);
+      expect(find.byKey(Key('$q1004Exam-exam')), findsNothing);
+    });
+  });
+}

--- a/uni/test/integration/src/exams2_page_test.dart
+++ b/uni/test/integration/src/exams2_page_test.dart
@@ -109,8 +109,6 @@ void main() async {
       expect(examProvider.state!.contains(fis3022Exam), true);
       expect(examProvider.state!.contains(m2030Exam), true);
 
-      // print(exams);
-
       await tester.pumpAndSettle();
 
       expect(find.byKey(Key('$fis3022Exam-exam')), findsOneWidget);


### PR DESCRIPTION
Closes #800 
In Sigarra's exams page for FCUP and other faculties, some exams have their begin and end times in a different format, not previously supported by the Exams Parser. 

![image](https://github.com/NIAEFEUP/uni/assets/88210776/49b79041-3abe-4058-b826-2587b17c262a)



# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
