### PR TITLE
fix: display multiple rooms

### DIFF
--- a/uni/lib/view/schedule/widgets/schedule_slot.dart
+++ b/uni/lib/view/schedule/widgets/schedule_slot.dart
@@ -97,7 +97,7 @@ class ScheduleSlot extends StatelessWidget {
           ],
         ),
       ),
-      roomTextField
+      roomTextField,
     ];
   }
 }

--- a/uni/lib/view/schedule/widgets/schedule_slot.dart
+++ b/uni/lib/view/schedule/widgets/schedule_slot.dart
@@ -64,10 +64,9 @@ class ScheduleSlot extends StatelessWidget {
       style: Theme.of(context).textTheme.bodyMedium,
       alignment: TextAlign.center,
     );
-    final roomTextField = TextFieldWidget(
-      text: rooms,
+    final roomTextField = Text(
+      rooms,
       style: Theme.of(context).textTheme.bodyMedium,
-      alignment: TextAlign.right,
     );
     return [
       ScheduleTimeWidget(
@@ -98,7 +97,7 @@ class ScheduleSlot extends StatelessWidget {
           ],
         ),
       ),
-      roomTextField,
+      roomTextField
     ];
   }
 }


### PR DESCRIPTION
Closes #[issue number]

This PR fixes the class widget to show multiple rooms, if it has multiple rooms. Previously, all rooms after the first were not being shown.

![Screenshot_20240205-091103](https://github.com/NIAEFEUP/uni/assets/13498603/510721ca-0d4e-4236-a9f4-d4649d9d5f45)

![Screenshot_20240205-095250](https://github.com/NIAEFEUP/uni/assets/13498603/722f6c0a-c2f8-4e24-9fd0-9d75471ee77e)

# Review checklist
- [x] Terms and conditions reflect the current change
- [x] Contains enough appropriate tests
- [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
- [ ] Properly adds an entry in `changelog.md` with the change
- [x] If PR includes UI updates/additions, its description has screenshots
- [x] Behavior is as expected
- [x] Clean, well-structured code
