### PR TITLE
fix: use cached profile image on navigation

### DIFF
--- a/uni/.gitignore
+++ b/uni/.gitignore
@@ -125,3 +125,6 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+
+# Flutter Devtools
+devtools_options.yaml

--- a/uni/lib/view/common_widgets/pages_layouts/general/general.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/general.dart
@@ -17,7 +17,6 @@ abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
   final double borderMargin = 18;
   bool _loadedOnce = false;
   bool _loading = true;
-  static ImageProvider? profileImageProvider;
 
   Future<void> onRefresh(BuildContext context);
 

--- a/uni/lib/view/common_widgets/pages_layouts/general/widgets/profile_button.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/widgets/profile_button.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:uni/model/providers/startup/profile_provider.dart';
 import 'package:uni/model/providers/startup/session_provider.dart';
-import 'package:uni/view/common_widgets/pages_layouts/general/general.dart';
 import 'package:uni/view/profile/profile.dart';
 
 class ProfileButton extends StatelessWidget {
@@ -22,8 +21,7 @@ class ProfileButton extends StatelessWidget {
     final profilePictureFile =
         await ProfileProvider.fetchOrGetCachedProfilePicture(
       sessionProvider.state!,
-      forceRetrieval:
-          forceRetrieval || GeneralPageViewState.profileImageProvider == null,
+      forceRetrieval: forceRetrieval,
     );
     return getProfileDecorationImage(profilePictureFile);
   }


### PR DESCRIPTION
This PR prevents the users' profile image from being downloaded on every app navigation. It seems some legacy code was kept and it was preventing the cache mechanism from working properly.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [x] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
