### PR TITLE
ci: create env file for deployments

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,6 @@ jobs:
       actions: "write"
     name: "Bump version and Build App Bundle"
     runs-on: ubuntu-latest
-    needs: [bump_version]
     env:
       PROPERTIES_PATH: "android/key.properties"
       JAVA_VERSION: "17.x"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -116,6 +116,9 @@ jobs:
           echo "keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}" >> ${{env.PROPERTIES_PATH}}
           echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" >> ${{env.PROPERTIES_PATH}}
 
+      - name: Create .env file
+        run: echo "${{env.UNI_ENV_FILE}}" > ./assets/env/.env
+        
       - name: Build Android App Bundle
         run: |
           flutter pub get

--- a/uni/assets/env/.env.example
+++ b/uni/assets/env/.env.example
@@ -1,0 +1,3 @@
+# Plausbile
+PLAUSIBLE_URL=https://plausible.example.com
+PLAUSIBLE_DOMAIN=your.plausible.domain


### PR DESCRIPTION
Closes #1112.

This PR changes the CI to create the .env file that is bundled into uni.
To configure this env file, an env variable named UNI_ENV_FILE is used to set the file contents. Different environments for the main and develop branch may be used to distinguish between "beta" uni and "stable" uni.

I can't test this, so I call on @LuisDuarte1 to give his input on whether this would work.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
