### PR TITLE
ci: fix missing var

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -116,7 +116,7 @@ jobs:
           echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" >> ${{env.PROPERTIES_PATH}}
 
       - name: Create .env file
-        run: echo "${{env.UNI_ENV_FILE}}" > ./assets/env/.env
+        run: echo "${{vars.UNI_ENV_FILE}}" > ./assets/env/.env
         
       - name: Build Android App Bundle
         run: |


### PR DESCRIPTION
This PR fixes an issue where variables from github environments can only be accessed through the vars context.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
