### PR TITLE
fix: use new endpoint for calendar

### DIFF
--- a/uni/lib/controller/fetchers/calendar_fetcher_html.dart
+++ b/uni/lib/controller/fetchers/calendar_fetcher_html.dart
@@ -11,7 +11,7 @@ class CalendarFetcherHtml implements SessionDependantFetcher {
     // TODO(bdmendes): Implement parsers for all faculties
     // and dispatch for different fetchers
     final url = '${NetworkRouter.getBaseUrl('feup')}'
-        'web_base.gera_pagina?p_pagina=página%20estática%20genérica%20106';
+        'web_base.gera_pagina?p_pagina=calend%c3%a1rio%20escolar';
     return [url];
   }
 


### PR DESCRIPTION
Closes #1133.

This page changes the endpoint of the calendar to one that doesn't return a 403 error.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
