### PR TITLE
feat: add tooltips to navbar and remove splash effect

### DIFF
--- a/uni/lib/utils/navbar_items.dart
+++ b/uni/lib/utils/navbar_items.dart
@@ -28,7 +28,8 @@ enum NavbarItem {
   final NavigationItem item;
 
   BottomNavigationBarItem toUnselectedBottomNavigationBarItem(
-      BuildContext context) {
+    BuildContext context,
+  ) {
     return BottomNavigationBarItem(
       icon: Icon(unselectedIcon),
       label: '',
@@ -37,7 +38,8 @@ enum NavbarItem {
   }
 
   BottomNavigationBarItem toSelectedBottomNavigationBarItem(
-      BuildContext context) {
+    BuildContext context,
+  ) {
     return BottomNavigationBarItem(
       icon: Icon(selectedIcon),
       label: '',

--- a/uni/lib/utils/navbar_items.dart
+++ b/uni/lib/utils/navbar_items.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:uni/generated/l10n.dart';
 import 'package:uni/utils/navigation_items.dart';
 
 enum NavbarItem {
@@ -26,17 +27,21 @@ enum NavbarItem {
   final IconData selectedIcon;
   final NavigationItem item;
 
-  BottomNavigationBarItem toUnselectedBottomNavigationBarItem() {
+  BottomNavigationBarItem toUnselectedBottomNavigationBarItem(
+      BuildContext context) {
     return BottomNavigationBarItem(
       icon: Icon(unselectedIcon),
       label: '',
+      tooltip: S.of(context).nav_title(item.route),
     );
   }
 
-  BottomNavigationBarItem toSelectedBottomNavigationBarItem() {
+  BottomNavigationBarItem toSelectedBottomNavigationBarItem(
+      BuildContext context) {
     return BottomNavigationBarItem(
       icon: Icon(selectedIcon),
       label: '',
+      tooltip: S.of(context).nav_title(item.route),
     );
   }
 

--- a/uni/lib/view/common_widgets/pages_layouts/general/widgets/bottom_navigation_bar.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/widgets/bottom_navigation_bar.dart
@@ -44,23 +44,28 @@ class AppBottomNavbar extends StatelessWidget {
       navbarItems.insert(
         index,
         index == currentIndex
-            ? item.toSelectedBottomNavigationBarItem()
-            : item.toUnselectedBottomNavigationBarItem(),
+            ? item.toSelectedBottomNavigationBarItem(context)
+            : item.toUnselectedBottomNavigationBarItem(context),
       );
     }
 
-    return BottomNavigationBar(
-      items: navbarItems,
-      onTap: (int index) => _onItemTapped(context, index),
-      currentIndex: currentIndex == -1 ? 0 : currentIndex,
-      type: BottomNavigationBarType.fixed,
-      iconSize: 32,
-      selectedItemColor: currentIndex == -1
-          ? Theme.of(context).colorScheme.onSurface
-          : Theme.of(context).colorScheme.secondary,
-      unselectedItemColor: Theme.of(context).colorScheme.onSurface,
-      showSelectedLabels: false,
-      showUnselectedLabels: false,
-    );
+    return Theme(
+        data: Theme.of(context).copyWith(
+          splashColor: Colors.transparent,
+          highlightColor: Colors.transparent,
+        ),
+        child: BottomNavigationBar(
+          items: navbarItems,
+          onTap: (int index) => _onItemTapped(context, index),
+          currentIndex: currentIndex == -1 ? 0 : currentIndex,
+          type: BottomNavigationBarType.fixed,
+          iconSize: 32,
+          selectedItemColor: currentIndex == -1
+              ? Theme.of(context).colorScheme.onSurface
+              : Theme.of(context).colorScheme.secondary,
+          unselectedItemColor: Theme.of(context).colorScheme.onSurface,
+          showSelectedLabels: false,
+          showUnselectedLabels: false,
+        ));
   }
 }

--- a/uni/lib/view/common_widgets/pages_layouts/general/widgets/bottom_navigation_bar.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/widgets/bottom_navigation_bar.dart
@@ -50,22 +50,23 @@ class AppBottomNavbar extends StatelessWidget {
     }
 
     return Theme(
-        data: Theme.of(context).copyWith(
-          splashColor: Colors.transparent,
-          highlightColor: Colors.transparent,
-        ),
-        child: BottomNavigationBar(
-          items: navbarItems,
-          onTap: (int index) => _onItemTapped(context, index),
-          currentIndex: currentIndex == -1 ? 0 : currentIndex,
-          type: BottomNavigationBarType.fixed,
-          iconSize: 32,
-          selectedItemColor: currentIndex == -1
-              ? Theme.of(context).colorScheme.onSurface
-              : Theme.of(context).colorScheme.secondary,
-          unselectedItemColor: Theme.of(context).colorScheme.onSurface,
-          showSelectedLabels: false,
-          showUnselectedLabels: false,
-        ));
+      data: Theme.of(context).copyWith(
+        splashColor: Colors.transparent,
+        highlightColor: Colors.transparent,
+      ),
+      child: BottomNavigationBar(
+        items: navbarItems,
+        onTap: (int index) => _onItemTapped(context, index),
+        currentIndex: currentIndex == -1 ? 0 : currentIndex,
+        type: BottomNavigationBarType.fixed,
+        iconSize: 32,
+        selectedItemColor: currentIndex == -1
+            ? Theme.of(context).colorScheme.onSurface
+            : Theme.of(context).colorScheme.secondary,
+        unselectedItemColor: Theme.of(context).colorScheme.onSurface,
+        showSelectedLabels: false,
+        showUnselectedLabels: false,
+      ),
+    );
   }
 }


### PR DESCRIPTION
Closes #1149 and closes #1147.

This PR adds tooltips to the navbar items and removes the splash animations.

https://github.com/NIAEFEUP/uni/assets/13498603/ae2a4ee5-3e38-4854-943d-6032dbb2911e

> [!NOTE]
> In the video, the tooltips appear when I hold my finger on the icons for about one second.

# Review checklist

-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
