### PR TITLE
feat: add titles to general pages

### DIFF
--- a/uni/lib/view/academic_path/academic_path.dart
+++ b/uni/lib/view/academic_path/academic_path.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:uni/generated/l10n.dart';
+import 'package:uni/utils/navigation_items.dart';
 import 'package:uni/view/academic_path/widgets/course_units_card.dart';
 import 'package:uni/view/common_widgets/generic_card.dart';
 import 'package:uni/view/common_widgets/pages_layouts/general/general.dart';
@@ -19,6 +21,10 @@ class AcademicPathPageViewState extends GeneralPageViewState {
     CourseUnitsCard(),
     // Add more cards if needed
   ];
+
+  @override
+  String? getTitle() =>
+      S.of(context).nav_title(NavigationItem.navAcademicPath.route);
 
   @override
   Widget getBody(BuildContext context) {

--- a/uni/lib/view/common_widgets/page_title.dart
+++ b/uni/lib/view/common_widgets/page_title.dart
@@ -22,7 +22,7 @@ class PageTitle extends StatelessWidget {
     );
     return Container(
       padding: pad ? const EdgeInsets.fromLTRB(20, 30, 20, 10) : null,
-      alignment: center ? Alignment.center : null,
+      alignment: center ? Alignment.center : Alignment.centerLeft,
       child: title,
     );
   }

--- a/uni/lib/view/common_widgets/pages_layouts/general/general.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/general.dart
@@ -8,6 +8,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:uni/model/providers/startup/profile_provider.dart';
 import 'package:uni/model/providers/startup/session_provider.dart';
 import 'package:uni/view/common_widgets/pages_layouts/general/widgets/bottom_navigation_bar.dart';
+import 'package:uni/view/common_widgets/pages_layouts/general/widgets/profile_button.dart';
 import 'package:uni/view/common_widgets/pages_layouts/general/widgets/refresh_state.dart';
 import 'package:uni/view/common_widgets/pages_layouts/general/widgets/top_navigation_bar.dart';
 
@@ -62,6 +63,8 @@ abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
     );
   }
 
+  String? getTitle();
+
   Widget getBody(BuildContext context);
 
   Future<DecorationImage> buildProfileDecorationImage(
@@ -114,13 +117,18 @@ abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
 
   Widget getScaffold(BuildContext context, Widget body) {
     return Scaffold(
-      appBar: getTopNavbar(context),
       bottomNavigationBar: const AppBottomNavbar(),
+      appBar: getTopNavbar(context),
       body: RefreshState(onRefresh: onRefresh, child: body),
     );
   }
 
   AppTopNavbar? getTopNavbar(BuildContext context) {
-    return null;
+    return AppTopNavbar(
+      title: this.getTitle(),
+      rightButton: ProfileButton(
+        getProfileDecorationImage: getProfileDecorationImage,
+      ),
+    );
   }
 }

--- a/uni/lib/view/common_widgets/pages_layouts/general/widgets/top_navigation_bar.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/widgets/top_navigation_bar.dart
@@ -15,6 +15,33 @@ class AppTopNavbar extends StatelessWidget implements PreferredSizeWidget {
   final Widget? rightButton;
   final Widget? leftButton;
 
+  Widget _createTopWidgets(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(leftButton == null ? 20 : 12, 0, 8, 8),
+      child: Row(
+        children: [
+          if (leftButton != null)
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: leftButton,
+            ),
+          Expanded(
+            child: PageTitle(
+              name: title ?? '',
+              pad: false,
+              center: false,
+            ),
+          ),
+          if (rightButton != null)
+            Padding(
+              padding: const EdgeInsets.only(left: 8),
+              child: rightButton,
+            ),
+        ],
+      ),
+    );
+  }
+
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
 
@@ -24,27 +51,11 @@ class AppTopNavbar extends StatelessWidget implements PreferredSizeWidget {
       automaticallyImplyLeading: false,
       elevation: 0,
       iconTheme: Theme.of(context).iconTheme,
-      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
+      shadowColor: Theme.of(context).dividerColor,
+      surfaceTintColor: Theme.of(context).colorScheme.onSecondary,
       titleSpacing: 0,
-      title: Stack(
-        alignment: Alignment.center,
-        children: [
-          Align(
-            alignment: Alignment.centerLeft,
-            child: leftButton,
-          ),
-          Center(
-            child: PageTitle(
-              name: title ?? '',
-              pad: false,
-            ),
-          ),
-          Align(
-            alignment: Alignment.centerRight,
-            child: rightButton,
-          ),
-        ],
-      ),
+      title: _createTopWidgets(context),
     );
   }
 }

--- a/uni/lib/view/common_widgets/pages_layouts/secondary/secondary.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/secondary/secondary.dart
@@ -17,6 +17,7 @@ abstract class SecondaryPageViewState<T extends StatefulWidget>
     );
   }
 
+  @override
   String? getTitle();
 
   Widget? getTopRightButton(BuildContext context) {
@@ -28,10 +29,7 @@ abstract class SecondaryPageViewState<T extends StatefulWidget>
   AppTopNavbar? getTopNavbar(BuildContext context) {
     return AppTopNavbar(
       title: getTitle(),
-      leftButton: const Padding(
-        padding: EdgeInsets.symmetric(horizontal: 8),
-        child: BackButton(),
-      ),
+      leftButton: const BackButton(),
       rightButton: getTopRightButton(context),
     );
   }

--- a/uni/lib/view/faculty/faculty.dart
+++ b/uni/lib/view/faculty/faculty.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:uni/generated/l10n.dart';
 import 'package:uni/model/providers/lazy/library_occupation_provider.dart';
+import 'package:uni/utils/navigation_items.dart';
 import 'package:uni/view/calendar/widgets/calendar_card.dart';
 import 'package:uni/view/common_widgets/generic_expansion_card.dart';
 import 'package:uni/view/common_widgets/pages_layouts/general/general.dart';
@@ -21,6 +23,10 @@ class FacultyPageView extends StatefulWidget {
 }
 
 class FacultyPageViewState extends GeneralPageViewState {
+  @override
+  String? getTitle() =>
+      S.of(context).nav_title(NavigationItem.navFaculty.route);
+
   @override
   Widget getBody(BuildContext context) {
     return ListView(

--- a/uni/lib/view/home/home.dart
+++ b/uni/lib/view/home/home.dart
@@ -74,17 +74,17 @@ class HomePageViewState extends GeneralPageViewState {
   }
 
   @override
+  String? getTitle() => null;
+
+  @override
   AppTopNavbar? getTopNavbar(BuildContext context) {
     return AppTopNavbar(
       leftButton: const Padding(
-        padding: EdgeInsets.symmetric(horizontal: 8),
-        child: UniIcon(),
-      ),
-      rightButton: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8),
-        child: ProfileButton(
-          getProfileDecorationImage: getProfileDecorationImage,
-        ),
+        child: const UniIcon(),
+      ),
+      rightButton: ProfileButton(
+        getProfileDecorationImage: getProfileDecorationImage,
       ),
     );
   }

--- a/uni/lib/view/home/home.dart
+++ b/uni/lib/view/home/home.dart
@@ -80,8 +80,8 @@ class HomePageViewState extends GeneralPageViewState {
   AppTopNavbar? getTopNavbar(BuildContext context) {
     return AppTopNavbar(
       leftButton: const Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8),
-        child: const UniIcon(),
+        padding: EdgeInsets.symmetric(horizontal: 8),
+        child: UniIcon(),
       ),
       rightButton: ProfileButton(
         getProfileDecorationImage: getProfileDecorationImage,

--- a/uni/lib/view/home/widgets/main_cards_list.dart
+++ b/uni/lib/view/home/widgets/main_cards_list.dart
@@ -148,7 +148,7 @@ class MainCardsListState extends State<MainCardsList> {
     BuildContext context,
   ) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 0),
+      padding: const EdgeInsets.symmetric(horizontal: 20),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [

--- a/uni/lib/view/home/widgets/main_cards_list.dart
+++ b/uni/lib/view/home/widgets/main_cards_list.dart
@@ -66,6 +66,7 @@ class MainCardsListState extends State<MainCardsList> {
                   ),
                 )
               : ListView(
+                  padding: EdgeInsets.zero,
                   children: <Widget>[
                     createTopBar(context),
                     ...favoriteCardsFromTypes(
@@ -147,7 +148,7 @@ class MainCardsListState extends State<MainCardsList> {
     BuildContext context,
   ) {
     return Container(
-      padding: const EdgeInsets.fromLTRB(20, 10, 20, 0),
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 0),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [

--- a/uni/lib/view/home/widgets/uni_icon.dart
+++ b/uni/lib/view/home/widgets/uni_icon.dart
@@ -9,16 +9,13 @@ class UniIcon extends StatelessWidget {
     return ButtonTheme(
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
       shape: const RoundedRectangleBorder(),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12),
-        child: SvgPicture.asset(
-          colorFilter: ColorFilter.mode(
-            Theme.of(context).primaryColor,
-            BlendMode.srcIn,
-          ),
-          'assets/images/logo_dark.svg',
-          height: 35,
+      child: SvgPicture.asset(
+        colorFilter: ColorFilter.mode(
+          Theme.of(context).primaryColor,
+          BlendMode.srcIn,
         ),
+        'assets/images/logo_dark.svg',
+        height: 35,
       ),
     );
   }

--- a/uni/lib/view/restaurant/restaurant_page_view.dart
+++ b/uni/lib/view/restaurant/restaurant_page_view.dart
@@ -5,6 +5,7 @@ import 'package:uni/model/entities/meal.dart';
 import 'package:uni/model/entities/restaurant.dart';
 import 'package:uni/model/providers/lazy/restaurant_provider.dart';
 import 'package:uni/model/utils/day_of_week.dart';
+import 'package:uni/utils/navigation_items.dart';
 import 'package:uni/view/common_widgets/pages_layouts/general/general.dart';
 import 'package:uni/view/lazy_consumer.dart';
 import 'package:uni/view/locale_notifier.dart';
@@ -35,6 +36,10 @@ class _RestaurantPageViewState extends GeneralPageViewState<RestaurantPageView>
   }
 
   @override
+  String? getTitle() =>
+      S.of(context).nav_title(NavigationItem.navRestaurants.route);
+
+  @override
   Widget getBody(BuildContext context) {
     return Column(
       children: [
@@ -42,7 +47,6 @@ class _RestaurantPageViewState extends GeneralPageViewState<RestaurantPageView>
           controller: tabController,
           isScrollable: true,
           tabs: createTabs(context),
-          padding: const EdgeInsets.only(top: 40),
         ),
         LazyConsumer<RestaurantProvider, List<Restaurant>>(
           builder: (context, restaurants) => createTabViewBuilder(

--- a/uni/lib/view/transports/transports.dart
+++ b/uni/lib/view/transports/transports.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:uni/generated/l10n.dart';
+import 'package:uni/utils/navigation_items.dart';
 import 'package:uni/view/common_widgets/generic_card.dart';
 import 'package:uni/view/common_widgets/pages_layouts/general/general.dart';
 import 'package:uni/view/home/widgets/bus_stop_card.dart';
@@ -17,6 +19,10 @@ class TransportsPageViewState extends GeneralPageViewState {
     BusStopCard(),
     // Add more cards if needed
   ];
+
+  @override
+  String? getTitle() =>
+      S.of(context).nav_title(NavigationItem.navTransports.route);
 
   @override
   Widget getBody(BuildContext context) {


### PR DESCRIPTION
Closes #1146 

This PR adds titles to the general pages. It also fixes some appearance issues with the App Bar.

# Screen recording

https://github.com/NIAEFEUP/uni/assets/13498603/98cecaaf-0d87-4ce3-87ec-6fdb7d7fab56

https://github.com/NIAEFEUP/uni/assets/13498603/19141195-80f1-464d-9f95-aff871c6bea2

# Detailed Changelog

- Method `getTitle` was added to general pages. This method returns the title string that is used in the UI. Localized strings are used to adapt to user's language setting.
- Page titles are not left aligned, unless center property is true (legacy behaviour)
- Profile button was also added to the app bar on the general page layout.
- Colors were adjusted in the app bar and shadows were added to it.


# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
