### PR TITLE
fix: profile button is no longer clipped on navbar

### DIFF
--- a/uni/lib/view/common_widgets/pages_layouts/general/general.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/general.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
@@ -67,34 +66,6 @@ abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
 
   Widget getBody(BuildContext context);
 
-  Future<DecorationImage> buildProfileDecorationImage(
-    BuildContext context, {
-    bool forceRetrieval = false,
-  }) async {
-    final sessionProvider =
-        Provider.of<SessionProvider>(context, listen: false);
-    await sessionProvider.ensureInitialized(context);
-    final profilePictureFile =
-        await ProfileProvider.fetchOrGetCachedProfilePicture(
-      sessionProvider.state!,
-      forceRetrieval: forceRetrieval,
-    );
-    return getProfileDecorationImage(profilePictureFile);
-  }
-
-  /// Returns the current user image.
-  ///
-  /// If the image is not found / doesn't exist returns a generic placeholder.
-  DecorationImage getProfileDecorationImage(File? profilePicture) {
-    const fallbackPicture = AssetImage('assets/images/profile_placeholder.png');
-    final image =
-        profilePicture == null ? fallbackPicture : FileImage(profilePicture);
-
-    final result =
-        DecorationImage(fit: BoxFit.cover, image: image as ImageProvider);
-    return result;
-  }
-
   Widget refreshState(BuildContext context, Widget child) {
     return RefreshIndicator(
       key: GlobalKey<RefreshIndicatorState>(),
@@ -126,9 +97,7 @@ abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
   AppTopNavbar? getTopNavbar(BuildContext context) {
     return AppTopNavbar(
       title: this.getTitle(),
-      rightButton: ProfileButton(
-        getProfileDecorationImage: getProfileDecorationImage,
-      ),
+      rightButton: const ProfileButton(),
     );
   }
 }

--- a/uni/lib/view/common_widgets/pages_layouts/general/widgets/profile_button.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/widgets/profile_button.dart
@@ -1,58 +1,24 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import 'package:uni/model/providers/startup/profile_provider.dart';
-import 'package:uni/model/providers/startup/session_provider.dart';
 import 'package:uni/utils/navigation_items.dart';
+import 'package:uni/view/common_widgets/widgets/profile_image.dart';
 
 class ProfileButton extends StatelessWidget {
-  const ProfileButton({required this.getProfileDecorationImage, super.key});
-
-  final DecorationImage Function(File?) getProfileDecorationImage;
-
-  Future<DecorationImage> buildProfileDecorationImage(
-    BuildContext context, {
-    bool forceRetrieval = false,
-  }) async {
-    final sessionProvider =
-        Provider.of<SessionProvider>(context, listen: false);
-    await sessionProvider.ensureInitialized(context);
-    final profilePictureFile =
-        await ProfileProvider.fetchOrGetCachedProfilePicture(
-      sessionProvider.state!,
-      forceRetrieval: forceRetrieval,
-    );
-    return getProfileDecorationImage(profilePictureFile);
-  }
+  const ProfileButton({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder(
-      future: buildProfileDecorationImage(context),
-      builder: (
-        BuildContext context,
-        AsyncSnapshot<DecorationImage> decorationImage,
-      ) {
-        return IconButton(
-          style: IconButton.styleFrom(
-            padding: const EdgeInsets.all(5),
-            shape: const CircleBorder(),
-          ),
-          onPressed: () => {
-            Navigator.pushNamed(
-              context,
-              '/${NavigationItem.navProfile.route}',
-            ),
-          },
-          icon: CircleAvatar(
-            radius: 20,
-            foregroundImage: decorationImage.data?.image,
-            backgroundImage:
-                const AssetImage('assets/images/profile_placeholder.png'),
-          ),
-        );
+    return IconButton(
+      style: IconButton.styleFrom(
+        padding: const EdgeInsets.all(5),
+        shape: const CircleBorder(),
+      ),
+      onPressed: () => {
+        Navigator.pushNamed(
+          context,
+          '/${NavigationItem.navProfile.route}',
+        ),
       },
+      icon: const ProfileImage(radius: 20),
     );
   }
 }

--- a/uni/lib/view/common_widgets/pages_layouts/general/widgets/profile_button.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/widgets/profile_button.dart
@@ -34,20 +34,22 @@ class ProfileButton extends StatelessWidget {
         BuildContext context,
         AsyncSnapshot<DecorationImage> decorationImage,
       ) {
-        return TextButton(
+        return IconButton(
+          style: IconButton.styleFrom(
+            padding: const EdgeInsets.all(5),
+            shape: const CircleBorder(),
+          ),
           onPressed: () => {
             Navigator.pushNamed(
               context,
               '/${NavigationItem.navProfile.route}',
             ),
           },
-          child: Container(
-            width: 50,
-            height: 50,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              image: decorationImage.data,
-            ),
+          icon: CircleAvatar(
+            radius: 20,
+            foregroundImage: decorationImage.data?.image,
+            backgroundImage:
+                const AssetImage('assets/images/profile_placeholder.png'),
           ),
         );
       },

--- a/uni/lib/view/common_widgets/pages_layouts/general/widgets/top_navigation_bar.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/widgets/top_navigation_bar.dart
@@ -17,7 +17,7 @@ class AppTopNavbar extends StatelessWidget implements PreferredSizeWidget {
 
   Widget _createTopWidgets(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.fromLTRB(leftButton == null ? 20 : 12, 0, 8, 8),
+      padding: EdgeInsets.fromLTRB(leftButton == null ? 20 : 12, 0, 20, 0),
       child: Row(
         children: [
           if (leftButton != null)

--- a/uni/lib/view/common_widgets/widgets/profile_image.dart
+++ b/uni/lib/view/common_widgets/widgets/profile_image.dart
@@ -30,13 +30,13 @@ class ProfileImage extends StatelessWidget {
   ///
   /// If the image is not found / doesn't exist returns null.
   DecorationImage? getProfileDecorationImage(File? profilePicture) {
-    if (profilePicture == null) {
-      return null;
-    }
+    final image = profilePicture != null
+        ? FileImage(profilePicture) as ImageProvider<Object>
+        : const AssetImage('assets/images/profile_placeholder.png');
 
     return DecorationImage(
       fit: BoxFit.cover,
-      image: FileImage(profilePicture),
+      image: image,
     );
   }
 
@@ -51,8 +51,6 @@ class ProfileImage extends StatelessWidget {
         return CircleAvatar(
           radius: radius,
           foregroundImage: decorationImage.data?.image,
-          // backgroundImage:
-          //     const AssetImage('assets/images/profile_placeholder.png'),
           backgroundColor: Colors.transparent,
         );
       },

--- a/uni/lib/view/common_widgets/widgets/profile_image.dart
+++ b/uni/lib/view/common_widgets/widgets/profile_image.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:uni/model/providers/startup/profile_provider.dart';
+import 'package:uni/model/providers/startup/session_provider.dart';
+
+class ProfileImage extends StatelessWidget {
+  const ProfileImage({
+    required this.radius,
+    super.key,
+  });
+
+  final double radius;
+
+  Future<DecorationImage?> buildProfileDecorationImage(
+    BuildContext context,
+  ) async {
+    final sessionProvider =
+        Provider.of<SessionProvider>(context, listen: false);
+    await sessionProvider.ensureInitialized(context);
+    final profilePictureFile =
+        await ProfileProvider.fetchOrGetCachedProfilePicture(
+      sessionProvider.state!,
+    );
+    return getProfileDecorationImage(profilePictureFile);
+  }
+
+  /// Returns the current user image.
+  ///
+  /// If the image is not found / doesn't exist returns null.
+  DecorationImage? getProfileDecorationImage(File? profilePicture) {
+    if (profilePicture == null) {
+      return null;
+    }
+
+    return DecorationImage(
+      fit: BoxFit.cover,
+      image: FileImage(profilePicture),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+      future: buildProfileDecorationImage(context),
+      builder: (
+        BuildContext context,
+        AsyncSnapshot<DecorationImage?> decorationImage,
+      ) {
+        return CircleAvatar(
+          radius: radius,
+          foregroundImage: decorationImage.data?.image,
+          // backgroundImage:
+          //     const AssetImage('assets/images/profile_placeholder.png'),
+          backgroundColor: Colors.transparent,
+        );
+      },
+    );
+  }
+}

--- a/uni/lib/view/home/home.dart
+++ b/uni/lib/view/home/home.dart
@@ -83,9 +83,7 @@ class HomePageViewState extends GeneralPageViewState {
         padding: EdgeInsets.symmetric(horizontal: 8),
         child: UniIcon(),
       ),
-      rightButton: ProfileButton(
-        getProfileDecorationImage: getProfileDecorationImage,
-      ),
+      rightButton: const ProfileButton(),
     );
   }
 }

--- a/uni/lib/view/home/home.dart
+++ b/uni/lib/view/home/home.dart
@@ -78,12 +78,12 @@ class HomePageViewState extends GeneralPageViewState {
 
   @override
   AppTopNavbar? getTopNavbar(BuildContext context) {
-    return AppTopNavbar(
-      leftButton: const Padding(
+    return const AppTopNavbar(
+      leftButton: Padding(
         padding: EdgeInsets.symmetric(horizontal: 8),
         child: UniIcon(),
       ),
-      rightButton: const ProfileButton(),
+      rightButton: ProfileButton(),
     );
   }
 }

--- a/uni/lib/view/profile/profile.dart
+++ b/uni/lib/view/profile/profile.dart
@@ -38,10 +38,7 @@ class ProfilePageViewState extends SecondaryPageViewState<ProfilePageView> {
           children: [
             const Padding(padding: EdgeInsets.all(5)),
             const Padding(padding: EdgeInsets.all(10)),
-            ProfileOverview(
-              profile: profile,
-              getProfileDecorationImage: getProfileDecorationImage,
-            ),
+            ProfileOverview(profile: profile),
             const Padding(padding: EdgeInsets.all(5)),
             ...courseWidgets,
             AccountInfoCard(),

--- a/uni/lib/view/profile/profile.dart
+++ b/uni/lib/view/profile/profile.dart
@@ -54,14 +54,11 @@ class ProfilePageViewState extends SecondaryPageViewState<ProfilePageView> {
 
   @override
   Widget getTopRightButton(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.fromLTRB(0, 10, 8, 10),
-      child: IconButton(
-        icon: const Icon(Icons.settings),
-        onPressed: () => Navigator.pushNamed(
-          context,
-          '/${NavigationItem.navSettings.route}',
-        ),
+    return IconButton(
+      icon: const Icon(Icons.settings),
+      onPressed: () => Navigator.pushNamed(
+        context,
+        '/${NavigationItem.navSettings.route}',
       ),
     );
   }

--- a/uni/lib/view/profile/widgets/profile_overview.dart
+++ b/uni/lib/view/profile/widgets/profile_overview.dart
@@ -5,16 +5,15 @@ import 'package:provider/provider.dart';
 import 'package:uni/model/entities/profile.dart';
 import 'package:uni/model/providers/startup/profile_provider.dart';
 import 'package:uni/model/providers/startup/session_provider.dart';
+import 'package:uni/view/common_widgets/widgets/profile_image.dart';
 
 class ProfileOverview extends StatelessWidget {
   const ProfileOverview({
     required this.profile,
-    required this.getProfileDecorationImage,
     super.key,
   });
 
   final Profile profile;
-  final DecorationImage Function(File?) getProfileDecorationImage;
 
   @override
   Widget build(BuildContext context) {
@@ -27,16 +26,7 @@ class ProfileOverview extends StatelessWidget {
           Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          Container(
-            width: 150,
-            height: 150,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              image: profilePic.data != null
-                  ? getProfileDecorationImage(profilePic.data)
-                  : null,
-            ),
-          ),
+          const ProfileImage(radius: 75),
           const Padding(padding: EdgeInsets.all(8)),
           Text(
             profile.name,


### PR DESCRIPTION
This PR fixes an issue with the profile button in the navbar.

The clipping occurred because the profile button had padding on the bottom, which made it move up and overflow.

I took this opportunity to extract a component called ProfileImage. Also, a CircleAvatar was used instead of a box decoration.

This also fixes a issue overlooked in the #1152 where the settings icon in the profile page had too much padding on the right.

# Screenrecording

https://github.com/NIAEFEUP/uni/assets/13498603/5b5f7f0d-4dda-4944-b322-d760301dcbe4

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
