### PR TITLE
feature/faculty-filter

### DIFF
--- a/uni/lib/view/common_widgets/faculty_filter.dart
+++ b/uni/lib/view/common_widgets/faculty_filter.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:uni/controller/local_storage/preferences_controller.dart';
+
+class FacultyFilter extends StatelessWidget {
+  const FacultyFilter({
+    required this.faculties,
+    required this.builder,
+    super.key,
+  });
+
+  final List<String> faculties;
+  final Widget Function(BuildContext context, List<String> authorizedFaculties)
+      builder;
+
+  @override
+  Widget build(BuildContext context) {
+    final authorizedFaculties = PreferencesController.getUserFaculties()
+        .where(
+          faculties.contains,
+        )
+        .toList();
+
+    return authorizedFaculties.isNotEmpty
+        ? builder(context, authorizedFaculties)
+        : Container();
+  }
+}


### PR DESCRIPTION
Closes #1114

- Created `FacultyFilter` widget (according to @limwa's API description)

- Example of usage:

```
FacultyFilter(
    faculties: const ['feup', 'fcup'],
    builder: (context, authorizedFaculties) => MapCard(),
);
```

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
