### PR TITLE
fix: add weekend schedule

### DIFF
--- a/uni/lib/generated/intl/messages_en.dart
+++ b/uni/lib/generated/intl/messages_en.dart
@@ -178,6 +178,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("No classes to present"),
         "no_classes_on":
             MessageLookupByLibrary.simpleMessage("You don\'t have classes on"),
+        "no_classes_on_weekend":
+            MessageLookupByLibrary.simpleMessage("You don\'t have classes on"),
         "no_college": MessageLookupByLibrary.simpleMessage("no college"),
         "no_course_units": MessageLookupByLibrary.simpleMessage(
             "No course units in the selected period"),

--- a/uni/lib/generated/intl/messages_pt_PT.dart
+++ b/uni/lib/generated/intl/messages_pt_PT.dart
@@ -179,6 +179,8 @@ class MessageLookup extends MessageLookupByLibrary {
             "Não existem aulas para apresentar"),
         "no_classes_on":
             MessageLookupByLibrary.simpleMessage("Não possui aulas à"),
+        "no_classes_on_weekend":
+            MessageLookupByLibrary.simpleMessage("Não possui aulas ao"),
         "no_college": MessageLookupByLibrary.simpleMessage("sem faculdade"),
         "no_course_units": MessageLookupByLibrary.simpleMessage(
             "Sem cadeiras no período selecionado"),

--- a/uni/lib/generated/l10n.dart
+++ b/uni/lib/generated/l10n.dart
@@ -928,6 +928,16 @@ class S {
     );
   }
 
+  /// `You don't have classes on`
+  String get no_classes_on_weekend {
+    return Intl.message(
+      'You don\'t have classes on',
+      name: 'no_classes_on_weekend',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `no college`
   String get no_college {
     return Intl.message(

--- a/uni/lib/l10n/intl_en.arb
+++ b/uni/lib/l10n/intl_en.arb
@@ -180,6 +180,8 @@
   "@no_classes": {},
   "no_classes_on": "You don't have classes on",
   "@no_classes_on": {},
+  "no_classes_on_weekend": "You don't have classes on",
+  "@no_classes_on_weekend": {},
   "no_college": "no college",
   "@no_college": {},
   "no_course_units": "No course units in the selected period",

--- a/uni/lib/l10n/intl_pt_PT.arb
+++ b/uni/lib/l10n/intl_pt_PT.arb
@@ -190,6 +190,8 @@
   "@no_classes": {},
   "no_classes_on": "Não possui aulas à",
   "@no_classes_on": {},
+  "no_classes_on_weekend": "Não possui aulas ao",
+  "@no_classes_on_weekend": {},
   "no_college": "sem faculdade",
   "@no_college": {},
   "no_course_units": "Sem cadeiras no período selecionado",

--- a/uni/lib/view/schedule/schedule.dart
+++ b/uni/lib/view/schedule/schedule.dart
@@ -55,10 +55,10 @@ class SchedulePageViewState extends State<SchedulePageView>
     super.initState();
     tabController = TabController(
       vsync: this,
-      length: 5,
+      length: 6,
     );
     final weekDay = DateTime.now().weekday;
-    final offset = (weekDay > 5) ? 0 : (weekDay - 1) % 5;
+    final offset = (weekDay > 6) ? 0 : (weekDay - 1) % 6;
     tabController?.animateTo(tabController!.index + offset);
   }
 
@@ -82,7 +82,7 @@ class SchedulePageViewState extends State<SchedulePageView>
         Expanded(
           child: TabBarView(
             controller: tabController,
-            children: Iterable<int>.generate(5).map((day) {
+            children: Iterable<int>.generate(6).map((day) {
               final lectures = lecturesOfDay(widget.lectures, day);
               if (lectures.isEmpty) {
                 return emptyDayColumn(context, day);
@@ -100,7 +100,7 @@ class SchedulePageViewState extends State<SchedulePageView>
   List<Widget> createTabs(MediaQueryData queryData, BuildContext context) {
     final tabs = <Widget>[];
     final workWeekDays =
-        context.read<LocaleNotifier>().getWeekdaysWithLocale().sublist(0, 5);
+        context.read<LocaleNotifier>().getWeekdaysWithLocale().sublist(0, 6);
     workWeekDays.asMap().forEach((index, day) {
       tabs.add(
         SizedBox(

--- a/uni/lib/view/schedule/schedule.dart
+++ b/uni/lib/view/schedule/schedule.dart
@@ -158,10 +158,14 @@ class SchedulePageViewState extends State<SchedulePageView>
     final weekday =
         Provider.of<LocaleNotifier>(context).getWeekdaysWithLocale()[day];
 
+    final noClassesText = day >= DateTime.saturday - 1
+        ? S.of(context).no_classes_on_weekend
+        : S.of(context).no_classes_on;
+
     return Center(
       child: ImageLabel(
         imagePath: 'assets/images/schedule.png',
-        label: '${S.of(context).no_classes_on} $weekday.',
+        label: '$noClassesText $weekday.',
         labelTextStyle: const TextStyle(fontSize: 15),
       ),
     );

--- a/uni/test/unit/view/Pages/exams_page_view_test.dart
+++ b/uni/test/unit/view/Pages/exams_page_view_test.dart
@@ -52,8 +52,6 @@ void main() async {
       await tester.pumpWidget(testableWidget(widget, providers: providers));
       await tester.pumpAndSettle();
 
-      debugDumpApp();
-
       expect(find.byKey(Key(firstExam.toString())), findsOneWidget);
       expect(find.byKey(Key('$firstExam-exam')), findsOneWidget);
     });


### PR DESCRIPTION
Closes #946.

Supersedes #1039.

In this PR, a tab for Saturday is added. Furthermore, a new translation for no classes on weekends is also added.


# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
