### PR TITLE
hotfix: null state on providers first use

### DIFF
--- a/uni/lib/main.dart
+++ b/uni/lib/main.dart
@@ -136,6 +136,9 @@ Future<void> main() async {
                 create: (context) => stateProviders.sessionProvider,
               ),
               ChangeNotifierProvider(
+                create: (context) => stateProviders.profileProvider,
+              ),
+              ChangeNotifierProvider(
                 create: (context) => stateProviders.lectureProvider,
               ),
               ChangeNotifierProvider(
@@ -146,9 +149,6 @@ Future<void> main() async {
               ),
               ChangeNotifierProvider(
                 create: (context) => stateProviders.restaurantProvider,
-              ),
-              ChangeNotifierProvider(
-                create: (context) => stateProviders.profileProvider,
               ),
               ChangeNotifierProvider(
                 create: (context) => stateProviders.courseUnitsInfoProvider,

--- a/uni/lib/main.dart
+++ b/uni/lib/main.dart
@@ -133,6 +133,9 @@ Future<void> main() async {
           child: MultiProvider(
             providers: [
               ChangeNotifierProvider(
+                create: (context) => stateProviders.sessionProvider,
+              ),
+              ChangeNotifierProvider(
                 create: (context) => stateProviders.lectureProvider,
               ),
               ChangeNotifierProvider(
@@ -149,9 +152,6 @@ Future<void> main() async {
               ),
               ChangeNotifierProvider(
                 create: (context) => stateProviders.courseUnitsInfoProvider,
-              ),
-              ChangeNotifierProvider(
-                create: (context) => stateProviders.sessionProvider,
               ),
               ChangeNotifierProvider(
                 create: (context) => stateProviders.calendarProvider,


### PR DESCRIPTION
Closes #1174.
This PR changes the order of providers so that session provider is loaded before profile, exams and lectures providers.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
