### PR TITLE
hotfix: retrieve bus stops' csrf token

### DIFF
--- a/uni/lib/controller/fetchers/departures_fetcher.dart
+++ b/uni/lib/controller/fetchers/departures_fetcher.dart
@@ -28,7 +28,7 @@ class DeparturesFetcher {
     final htmlResponse = parse(response.body);
 
     final scriptText = htmlResponse
-        .querySelectorAll('script')
+        .querySelectorAll('table script')
         .where((element) => element.text.contains(_stopCode))
         .map((e) => e.text)
         .first;


### PR DESCRIPTION
This PR changes the CSS selector used to retrieve the CSRF token in bus stops operations. 

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
