### PR TITLE
hotfix: proper error handling in plausible provider

### DIFF
--- a/uni/lib/model/providers/plausible/plausible_provider.dart
+++ b/uni/lib/model/providers/plausible/plausible_provider.dart
@@ -2,10 +2,12 @@ import 'dart:async';
 
 import 'package:battery_plus/battery_plus.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:logger/logger.dart';
 import 'package:plausible_analytics/plausible_analytics.dart';
 import 'package:provider/provider.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:uni/controller/local_storage/preferences_controller.dart';
 
 class PlausibleProvider extends StatefulWidget {
@@ -38,10 +40,19 @@ class _PlausibleProviderState extends State<PlausibleProvider> {
     if (plausible != null) {
       plausible.enabled = false;
 
-      _startListeners(plausible)
-          .then((_) => _updateBatteryState())
-          .then((_) => _updateConnectivityState())
-          .then((_) => _updateUsageStatsState());
+      unawaited(
+        _startListeners(plausible)
+            .then((_) => _updateBatteryState())
+            .then((_) => _updateConnectivityState())
+            .then((_) => _updateUsageStatsState())
+            .onError((error, stackTrace) {
+          unawaited(Sentry.captureException(error, stackTrace: stackTrace));
+          Logger().e(
+            'Error initializing plausible: $error',
+            stackTrace: stackTrace,
+          );
+        }),
+      );
     }
   }
 
@@ -67,7 +78,10 @@ class _PlausibleProviderState extends State<PlausibleProvider> {
 
     final battery = Battery();
     _batteryLevel = await battery.batteryLevel;
-    _isInBatterySaveMode = await battery.isInBatterySaveMode;
+
+    try {
+      _isInBatterySaveMode = await battery.isInBatterySaveMode;
+    } on PlatformException catch (_) {}
 
     _updateAnalyticsState();
   }

--- a/uni/lib/model/providers/plausible/plausible_provider.dart
+++ b/uni/lib/model/providers/plausible/plausible_provider.dart
@@ -81,7 +81,9 @@ class _PlausibleProviderState extends State<PlausibleProvider> {
 
     try {
       _isInBatterySaveMode = await battery.isInBatterySaveMode;
-    } on PlatformException catch (_) {}
+    } on PlatformException catch (_) {
+      _isInBatterySaveMode = false;
+    }
 
     _updateAnalyticsState();
   }


### PR DESCRIPTION
This PR adds proper error handling code to PlausibleProvider to protect from situations where devices don't implement battery save mode capabilities. If a device doesn't implement them, we consider that the device never is in battery saving mode.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
