### PR TITLE
hotfix: launch url with toast

### DIFF
--- a/uni/lib/controller/networking/url_launcher.dart
+++ b/uni/lib/controller/networking/url_launcher.dart
@@ -7,8 +7,14 @@ import 'package:url_launcher/url_launcher.dart';
 
 Future<void> launchUrlWithToast(BuildContext context, String url) async {
   final validUrl = Uri.parse(url);
-  if (url != '' && canLaunchUrl(validUrl) as bool) {
-    await launchUrl(Uri.parse(url));
+  final canLaunch = url != '' && await canLaunchUrl(validUrl);
+
+  if (!context.mounted) {
+    return;
+  }
+
+  if (canLaunch) {
+    await launchUrl(validUrl);
   } else {
     await ToastMessage.error(
       context,

--- a/uni/lib/view/locations/widgets/map.dart
+++ b/uni/lib/view/locations/widgets/map.dart
@@ -63,7 +63,9 @@ class LocationsMap extends StatelessWidget {
             color: Theme.of(context).colorScheme.onPrimary.withOpacity(0.8),
             child: GestureDetector(
               onTap: () => launchUrlWithToast(
-                  context, 'https://www.openstreetmap.org/copyright'),
+                context,
+                'https://www.openstreetmap.org/copyright',
+              ),
               child: const Padding(
                 padding: EdgeInsets.symmetric(vertical: 5, horizontal: 8),
                 child: MouseRegion(

--- a/uni/lib/view/locations/widgets/map.dart
+++ b/uni/lib/view/locations/widgets/map.dart
@@ -4,11 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_popup/flutter_map_marker_popup.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:uni/controller/networking/url_launcher.dart';
 import 'package:uni/model/entities/location_group.dart';
 import 'package:uni/view/locations/widgets/floorless_marker_popup.dart';
 import 'package:uni/view/locations/widgets/marker.dart';
 import 'package:uni/view/locations/widgets/marker_popup.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 class LocationsMap extends StatelessWidget {
   LocationsMap({
@@ -62,9 +62,8 @@ class LocationsMap extends StatelessWidget {
           child: ColoredBox(
             color: Theme.of(context).colorScheme.onPrimary.withOpacity(0.8),
             child: GestureDetector(
-              onTap: () => launchUrl(
-                Uri(host: 'openstreetmap.org', path: '/copyright'),
-              ),
+              onTap: () => launchUrlWithToast(
+                  context, 'https://www.openstreetmap.org/copyright'),
               child: const Padding(
                 padding: EdgeInsets.symmetric(vertical: 5, horizontal: 8),
                 child: MouseRegion(

--- a/uni/lib/view/login/login.dart
+++ b/uni/lib/view/login/login.dart
@@ -5,6 +5,7 @@ import 'package:flutter_svg/svg.dart';
 import 'package:logger/logger.dart';
 import 'package:provider/provider.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:uni/controller/networking/url_launcher.dart';
 import 'package:uni/generated/l10n.dart';
 import 'package:uni/model/entities/login_exceptions.dart';
 import 'package:uni/model/providers/startup/session_provider.dart';
@@ -14,7 +15,6 @@ import 'package:uni/view/common_widgets/toast_message.dart';
 import 'package:uni/view/home/widgets/exit_app_dialog.dart';
 import 'package:uni/view/login/widgets/inputs.dart';
 import 'package:uni/view/theme.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 class LoginPageView extends StatefulWidget {
   const LoginPageView({super.key});
@@ -248,7 +248,7 @@ class LoginPageViewState extends State<LoginPageView> {
               ),
         ),
       ),
-      onTap: () => launchUrl(Uri.parse('https://self-id.up.pt/reset')),
+      onTap: () => launchUrlWithToast(context, 'https://self-id.up.pt/reset'),
     );
   }
 
@@ -301,12 +301,8 @@ class LoginPageViewState extends State<LoginPageView> {
             ),
             ElevatedButton(
               child: Text(S.of(context).change),
-              onPressed: () async {
-                const url = 'https://self-id.up.pt/password';
-                if (await canLaunchUrl(Uri.parse(url))) {
-                  await launchUrl(Uri.parse(url));
-                }
-              },
+              onPressed: () =>
+                  launchUrlWithToast(context, 'https://self-id.up.pt/password'),
             ),
           ],
         );


### PR DESCRIPTION
Fixes an issue where the future returned by `canLaunchUrl` was being cast to a bool. Also refactors every launchUrl to use launchUrlWithToast.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
