### PR TITLE
Fix concurrency issue on deploy action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,6 +2,10 @@ on:
   push:
     branches: [master, develop]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 name: Deploy Action
 jobs:
   build:


### PR DESCRIPTION
This occurs when there are too many PRs merged in a 10-minute window. To avoid this, we set a concurrency group per branch (in this case only develop and master apply). I feel like canceling the previous deploy actions makes the merged PR less semantic because we technically lose track of where the hotfixes happened.
