### PR TITLE
hotfix: concurrent modification in bus stop provider

### DIFF
--- a/uni/lib/model/providers/lazy/bus_stop_provider.dart
+++ b/uni/lib/model/providers/lazy/bus_stop_provider.dart
@@ -59,7 +59,7 @@ class BusStopProvider extends StateProviderNotifier<Map<String, BusStopData>> {
     state!.remove(stopCode);
 
     notifyListeners();
-    await fetchUserBusTrips(state!);
+    await fetchUserBusTrips(Map.of(state!));
     notifyListeners();
 
     final db = AppBusStopDatabase();


### PR DESCRIPTION
This PR fixes a `ConcurrentModificationError`.

Stacktrace:
```
ConcurrentModificationError: Concurrent modification during iteration: _Map len:0.
  File "compact_hash.dart", line 714, in _CompactIterator.moveNext
  File "bus_stop_provider.dart", line 30, in BusStopProvider.fetchUserBusTrips
  File "<asynchronous suspension>"
  File "bus_stop_provider.dart", line 62, in BusStopProvider.removeUserBusStop
```

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
