### PR TITLE
CI: use `flutter-version-file` argument to subosito/flutter-action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ jobs:
           git fetch origin develop
           git pull origin master
           echo "DEVELOP_HASH=$(git rev-parse origin/develop)" >> $GITHUB_ENV
-          echo "MASTER_HASH=$(git rev-parse origin/master^2)" >> $GITHUB_ENV 
+          echo "MASTER_HASH=$(git rev-parse origin/master^2)" >> $GITHUB_ENV
 
       - name: Get latest version (develop)
         if: github.ref != 'refs/heads/master'
@@ -48,7 +48,7 @@ jobs:
           google_service_account_json: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
           package_name: ${{ secrets.ANDROID_PACKAGE_NAME }}
           track: "beta"
-      
+
       - name: Get latest production version
         uses: LuisDuarte1/google-play-latest-version-code@v0.2.1
         id: latest-production-version
@@ -56,7 +56,7 @@ jobs:
           google_service_account_json: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
           package_name: ${{ secrets.ANDROID_PACKAGE_NAME }}
           track: "production"
-      
+
       - name: Bump beta version
         uses: LuisDuarte1/semver-bump-environment@v1.0.0
         if: github.ref != 'refs/heads/master'
@@ -66,7 +66,7 @@ jobs:
           production_version: ${{ steps.latest-production-version.outputs.latest_version_name }}
           staging_version: ${{ steps.latest-beta-version.outputs.latest_version_name }}
           bump_type: prerelease
-      
+
       - name: Bump prod version (from develop)
         uses: LuisDuarte1/semver-bump-environment@v1.0.0
         if: github.ref == 'refs/heads/master' && env.MASTER_HASH == env.DEVELOP_HASH
@@ -84,7 +84,7 @@ jobs:
           current_environment: production
           production_version: ${{ steps.latest-production-version.outputs.latest_version_name }}
           bump_type: patch
-      
+
       - name: Combine output and write new version into file
         run: |
           export NEW_VERSION_NAME=${{ 
@@ -106,17 +106,11 @@ jobs:
           java-version: ${{env.JAVA_VERSION}}
           distribution: "zulu"
 
-      - uses: mikefarah/yq@master
-        name: Get Flutter version
-        id: get_flutter_version
-        with:
-          cmd: yq '.environment.flutter' uni/pubspec.yaml
-          
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: ${{ steps.get_flutter_version.outputs.result }}
+          flutter-version-file: uni/pubspec.yaml
           cache: true
 
       - name: Download Android keystore
@@ -133,7 +127,7 @@ jobs:
 
       - name: Create .env file
         run: echo "${{vars.UNI_ENV_FILE}}" > ./assets/env/.env
-        
+
       - name: Build Android App Bundle
         run: |
           flutter pub get

--- a/.github/workflows/format_lint_test.yaml
+++ b/.github/workflows/format_lint_test.yaml
@@ -17,17 +17,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      - uses: mikefarah/yq@master
-        name: Get Flutter version
-        id: get_flutter_version
-        with:
-          cmd: yq '.environment.flutter' uni/pubspec.yaml
-
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: ${{ steps.get_flutter_version.outputs.result }}
+          flutter-version-file: uni/pubspec.yaml
           cache: true
 
       - run: dart format $(find . -type f -name "*.dart" -a -not -name "*.g.dart" -a -not -name "*.mocks.dart") --set-exit-if-changed
@@ -48,17 +42,11 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: zulu
 
-      - uses: mikefarah/yq@master
-        name: Get Flutter version
-        id: get_flutter_version
-        with:
-          cmd: yq '.environment.flutter' uni/pubspec.yaml
-
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: ${{ steps.get_flutter_version.outputs.result }}
+          flutter-version-file: uni/pubspec.yaml
           cache: true
 
       - run: flutter analyze .
@@ -77,17 +65,11 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: zulu
 
-      - uses: mikefarah/yq@master
-        name: Get Flutter version
-        id: get_flutter_version
-        with:
-          cmd: yq '.environment.flutter' uni/pubspec.yaml
-
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: ${{ steps.get_flutter_version.outputs.result }}
+          flutter-version-file: uni/pubspec.yaml
           cache: true
 
       - name: Test with coverage


### PR DESCRIPTION
[I contributed this feature to subosito/flutter-action](https://github.com/subosito/flutter-action/releases/tag/v2.15.0). Now we don't have to use a separate `yq` step :-)

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [x] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
