### PR TITLE
hotfix: make week handle timezone changes

### DIFF
--- a/uni/lib/model/utils/time/week.dart
+++ b/uni/lib/model/utils/time/week.dart
@@ -1,3 +1,13 @@
+extension _ExactAddition on DateTime {
+  DateTime addExact(Duration duration) {
+    return copyWith(isUtc: true).add(duration).copyWith(isUtc: isUtc);
+  }
+
+  DateTime subtractExact(Duration duration) {
+    return copyWith(isUtc: true).subtract(duration).copyWith(isUtc: isUtc);
+  }
+}
+
 /// A [Week] represents a period of 7 days.
 class Week implements Comparable<Week> {
   /// Creates a [Week] that starts the given [start] **date** (not datetime).
@@ -12,7 +22,7 @@ class Week implements Comparable<Week> {
       microsecond: 0,
     );
 
-    final end = startAtMidnight.add(const Duration(days: 7));
+    final end = startAtMidnight.addExact(const Duration(days: 7));
 
     return Week._internal(startAtMidnight, end);
   }
@@ -32,20 +42,20 @@ class Week implements Comparable<Week> {
 
   /// Returns the [Week] that starts at the end of this [Week].
   Week next() {
-    return Week._internal(end, end.add(const Duration(days: 7)));
+    return Week._internal(end, end.addExact(const Duration(days: 7)));
   }
 
   /// Returns the [Week] that ends at the start of this [Week].
   Week previous() {
-    return Week._internal(start.subtract(const Duration(days: 7)), start);
+    return Week._internal(start.subtractExact(const Duration(days: 7)), start);
   }
 
   /// Returns the [Week] that is [duration] before this week.
   Week subtract(Duration duration) {
     final normalizedDuration = Duration(days: duration.inDays);
     return Week._internal(
-      start.subtract(normalizedDuration),
-      end.subtract(normalizedDuration),
+      start.subtractExact(normalizedDuration),
+      end.subtractExact(normalizedDuration),
     );
   }
 
@@ -53,8 +63,8 @@ class Week implements Comparable<Week> {
   Week add(Duration duration) {
     final normalizedDuration = Duration(days: duration.inDays);
     return Week._internal(
-      start.add(normalizedDuration),
-      end.add(normalizedDuration),
+      start.addExact(normalizedDuration),
+      end.addExact(normalizedDuration),
     );
   }
 
@@ -69,8 +79,8 @@ class Week implements Comparable<Week> {
     final offsetInDays = (weekday - start.weekday) % 7;
 
     return Week._internal(
-      start.add(Duration(days: offsetInDays)),
-      end.add(Duration(days: offsetInDays)),
+      start.addExact(Duration(days: offsetInDays)),
+      end.addExact(Duration(days: offsetInDays)),
     );
   }
 
@@ -84,8 +94,8 @@ class Week implements Comparable<Week> {
     final offsetInDays = (end.weekday - weekday) % 7;
 
     return Week._internal(
-      start.subtract(Duration(days: offsetInDays)),
-      end.subtract(Duration(days: offsetInDays)),
+      start.subtractExact(Duration(days: offsetInDays)),
+      end.subtractExact(Duration(days: offsetInDays)),
     );
   }
 
@@ -93,7 +103,7 @@ class Week implements Comparable<Week> {
   ///
   /// The values for [weekday] are according to [DateTime.weekday].
   DateTime getWeekday(int weekday) {
-    return start.add(Duration(days: (weekday - start.weekday) % 7));
+    return start.addExact(Duration(days: (weekday - start.weekday) % 7));
   }
 
   Iterable<DateTime> get weekdays {


### PR DESCRIPTION
This pull request makes the week util class handle timezone changes properly.

Dart's standard lib, when asked to add or subtract 7 days from a DateTime will, instead, add/subtract the equivalent of 7 days in seconds.

This results in wrong calculations when the week contains a timezone change. By copying the dates with `isUtc: true`, the calculations become correct, since UTC does not have timezone changes.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
