### PR TITLE
fixing password encoding in local storage

### DIFF
--- a/uni/lib/controller/local_storage/preferences_controller.dart
+++ b/uni/lib/controller/local_storage/preferences_controller.dart
@@ -79,7 +79,7 @@ class PreferencesController {
     List<String> faculties,
   ) async {
     await _secureStorage.write(key: _userNumber, value: user);
-    await _secureStorage.write(key: _userPw, value: pass);
+    await _secureStorage.write(key: _userPw, value: encode(pass));
     await prefs.setStringList(
       _userFaculties,
       faculties,
@@ -175,6 +175,7 @@ class PreferencesController {
   static Future<Tuple2<String, String>?> getPersistentUserInfo() async {
     final userNum = await getUserNumber();
     final userPass = await getUserPassword();
+
     if (userNum == null || userPass == null) {
       return null;
     }
@@ -281,11 +282,7 @@ class PreferencesController {
   /// Decrypts [base64Text].
   static String? decode(String base64Text) {
     final encrypter = _createEncrypter();
-    try {
-      return encrypter.decrypt64(base64Text, iv: iv);
-    } catch (_) {
-      return null;
-    }
+    return encrypter.decrypt64(base64Text, iv: iv);
   }
 
   /// Creates an [encrypt.Encrypter] for encrypting and decrypting the user's

--- a/uni/pubspec.lock
+++ b/uni/pubspec.lock
@@ -1343,10 +1343,10 @@ packages:
     dependency: "direct main"
     description:
       name: ua_client_hints
-      sha256: "8401d7bec261f61b3d3b61cd877653ddf840de2d9e07bd164f34588572aa0c8b"
+      sha256: ee3da4e4b6ed211fe54deaa19832dd25613f11fc2951912d4e62a093da03fbbb
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.1"
   unicode:
     dependency: transitive
     description:


### PR DESCRIPTION
Closes #1244 
We were not storing our passwords correctly, so when trying to retrieve it, `decode` would actually return `null`

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
