### PR TITLE
Abstract proguard rules at package level

### DIFF
--- a/uni/android/app/proguard-rules.pro
+++ b/uni/android/app/proguard-rules.pro
@@ -20,10 +20,13 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
-# The 6 lines below are added to fix #1243
--dontwarn com.google.errorprone.annotations.CanIgnoreReturnValue
--dontwarn com.google.errorprone.annotations.CheckReturnValue
--dontwarn com.google.errorprone.annotations.Immutable
--dontwarn com.google.errorprone.annotations.RestrictedApi
--dontwarn javax.annotation.Nullable
--dontwarn javax.annotation.concurrent.GuardedBy
+# These are annotations related to static analysis tools. Proguard 
+#  tries to optimize/obfuscate the bundle, it needs all
+#  packages to be present. Because these annotations do not exist
+#  at optimize time, it will warn us that it cannot find those packages.
+# Unfortunaly, AFAIK there's no real way to packages include their "own"
+#  proguard or some of them just do not do it, so we sometimes need to handle it
+#  when we add a new dependency. 
+
+-dontwarn com.google.errorprone.annotations.*
+-dontwarn javax.annotation.*


### PR DESCRIPTION
After some investigation on #1242, I've concluded that:

- `javax.annotations` has annotations included in the [JSR305](https://jcp.org/en/jsr/detail?id=305), which is a spec of annotations that help with IDEs or other tools to avoid software defects.
- `com.google.errorprone` has annotations related to [ErrorProne](https://errorprone.info/bugpatterns), a static analyzer with its own set of annotations like above.

These annotations are not reflected at runtime in any shape or form so, it's safe to ignore them (unfortunately, libs cannot specify what to ignore or not on proguard, so we need to do this by hand).

This PR groups the two annotation packages. 