### PR TITLE
Update proguard-rules.pro to include concurrent annotations

### DIFF
--- a/uni/android/app/proguard-rules.pro
+++ b/uni/android/app/proguard-rules.pro
@@ -30,3 +30,4 @@
 
 -dontwarn com.google.errorprone.annotations.*
 -dontwarn javax.annotation.*
+-dontwarn javax.annotation.concurrent.*


### PR DESCRIPTION
For some reason `javax.annotation.concurrent` is not covered by `javax.annotation.*`

