### PR TITLE
fix: schedule loading from storage

### DIFF
--- a/packages/uni_app/lib/controller/local_storage/database/app_lectures_database.dart
+++ b/packages/uni_app/lib/controller/local_storage/database/app_lectures_database.dart
@@ -20,7 +20,7 @@ class AppLecturesDatabase extends AppDatabase<List<Lecture>> {
         );
   static const createScript = '''
 CREATE TABLE lectures(subject TEXT, typeClass TEXT,
-          startTime TEXT,endTime TEXT, blocks INTEGER, room TEXT, teacher TEXT, classNumber TEXT, occurrId INTEGER)''';
+          startTime TEXT, endTime TEXT, blocks INTEGER, room TEXT, teacher TEXT, classNumber TEXT, occurrId INTEGER)''';
 
   /// Returns a list containing all of the lectures stored in this database.
   Future<List<Lecture>> lectures() async {
@@ -31,7 +31,7 @@ CREATE TABLE lectures(subject TEXT, typeClass TEXT,
       return Lecture.fromApi(
         maps[i]['subject'] as String,
         maps[i]['typeClass'] as String,
-        DateTime.parse(maps[i]['startDateTime'] as String),
+        DateTime.parse(maps[i]['startTime'] as String),
         maps[i]['blocks'] as int,
         maps[i]['room'] as String,
         maps[i]['teacher'] as String,


### PR DESCRIPTION
Fixes an issue where schedule loading presents an error when the app is first opened.
This is because the loadFromStorage method throws an unexpected error.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
