### PR TITLE
Fix schedule null api URL

### DIFF
--- a/packages/uni_app/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_new_api.dart
+++ b/packages/uni_app/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_new_api.dart
@@ -34,6 +34,10 @@ class ScheduleFetcherNewApi extends ScheduleFetcher {
 
       final scheduleApiUrl = getScheduleApiUrlFromHtml(scheduleResponse);
 
+      if (scheduleApiUrl == null) {
+        return <Lecture>[];
+      }
+
       final scheduleApiResponse = await NetworkRouter.getWithCookies(
         scheduleApiUrl,
         {},

--- a/packages/uni_app/lib/controller/parsers/schedule/new_api/parser.dart
+++ b/packages/uni_app/lib/controller/parsers/schedule/new_api/parser.dart
@@ -8,17 +8,13 @@ import 'package:uni/model/entities/lecture.dart';
 /// Extracts the user's lecture API URL.
 ///
 /// This function parses the schedule's HTML page.
-String getScheduleApiUrlFromHtml(
+String? getScheduleApiUrlFromHtml(
   http.Response response,
 ) {
   final document = parse(response.body);
 
   final scheduleElement = document.querySelector('#cal-shadow-container');
   final apiUrl = scheduleElement?.attributes['data-evt-source-url'];
-
-  if (apiUrl == null) {
-    throw Exception('Could not find schedule API URL in schedule page');
-  }
 
   return apiUrl;
 }


### PR DESCRIPTION
When a student does not have their schedule yet, the page does not have the required tag to access the api url.

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
