### PR TITLE
fix: lectures database serialization

### DIFF
--- a/packages/uni_app/lib/controller/local_storage/database/app_lectures_database.dart
+++ b/packages/uni_app/lib/controller/local_storage/database/app_lectures_database.dart
@@ -16,11 +16,11 @@ class AppLecturesDatabase extends AppDatabase<List<Lecture>> {
             createScript,
           ],
           onUpgrade: migrate,
-          version: 9,
+          version: 10,
         );
   static const createScript = '''
 CREATE TABLE lectures(subject TEXT, typeClass TEXT,
-          startTime TEXT, endTime TEXT, blocks INTEGER, room TEXT, teacher TEXT, classNumber TEXT, occurrId INTEGER)''';
+          startTime TEXT, endTime TEXT, room TEXT, teacher TEXT, classNumber TEXT, occurrId INTEGER)''';
 
   /// Returns a list containing all of the lectures stored in this database.
   Future<List<Lecture>> lectures() async {
@@ -28,11 +28,11 @@ CREATE TABLE lectures(subject TEXT, typeClass TEXT,
     final List<Map<String, dynamic>> maps = await db.query('lectures');
 
     return List.generate(maps.length, (i) {
-      return Lecture.fromApi(
+      return Lecture(
         maps[i]['subject'] as String,
         maps[i]['typeClass'] as String,
         DateTime.parse(maps[i]['startTime'] as String),
-        maps[i]['blocks'] as int,
+        DateTime.parse(maps[i]['endTime'] as String),
         maps[i]['room'] as String,
         maps[i]['teacher'] as String,
         maps[i]['classNumber'] as String,


### PR DESCRIPTION
Fixes an issue where the lectures are stored with NULL blocks.
When reading the lectures, an error is thrown when attempting to read the blocks field.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
