### PR TITLE
fix: error when there is no unit bibliography

### DIFF
--- a/packages/uni_app/lib/controller/parsers/parser_course_unit_info.dart
+++ b/packages/uni_app/lib/controller/parsers/parser_course_unit_info.dart
@@ -58,9 +58,8 @@ Future<Sheet> parseSheet(http.Response response) async {
     return Professor.fromJson(element as Map<String, dynamic>);
   }).toList();
 
-  final books = (json['bibliografia'] as List)
+  final books = (json['bibliografia'] as List? ?? [])
       .map((element) => element as Map<String, dynamic>)
-      .toList()
       .map<Book>((element) {
     return Book(
       title: element['titulo'].toString(),


### PR DESCRIPTION
This PR fixes an issue where fetching a curricular unit's details fails when there is no bibliography on SIGARRA for the unit.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
