### PR TITLE
fix: error when null progress in library

### DIFF
--- a/packages/uni_app/lib/controller/fetchers/library_occupation_fetcher.dart
+++ b/packages/uni_app/lib/controller/fetchers/library_occupation_fetcher.dart
@@ -49,7 +49,7 @@ class LibraryOccupationFetcher {
   ) {
     final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
 
-    final floorOccupation = int.parse(responseBody['progress'].toString());
+    final floorOccupation = responseBody['progress'] as int? ?? 0;
 
     return FloorOccupation(
       floor + 1,


### PR DESCRIPTION
This PR fixes an issue where library information fetching fails when there is null progress. We assume that `null` means 0 in the affluences API.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
