### PR TITLE
ci: upgrade upload-artifact

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -134,7 +134,7 @@ jobs:
           flutter build appbundle
 
       - name: Upload App Bundle
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: appbundle
           if-no-files-found: error


### PR DESCRIPTION
Upgrades upload-artifact. Needed because of upgrade to download-artifact.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
