### PR TITLE
refactor: remove profile from lecture provider

### DIFF
--- a/packages/uni_app/lib/controller/fetchers/schedule_fetcher/schedule_fetcher.dart
+++ b/packages/uni_app/lib/controller/fetchers/schedule_fetcher/schedule_fetcher.dart
@@ -1,13 +1,12 @@
 import 'package:uni/controller/fetchers/session_dependant_fetcher.dart';
 import 'package:uni/model/entities/lecture.dart';
-import 'package:uni/model/entities/profile.dart';
 import 'package:uni/model/utils/time/week.dart';
 import 'package:uni/session/flows/base/session.dart';
 
 /// Class for fetching the user's schedule.
 abstract class ScheduleFetcher extends SessionDependantFetcher {
   // Returns the user's lectures.
-  Future<List<Lecture>> getLectures(Session session, Profile profile);
+  Future<List<Lecture>> getLectures(Session session);
 
   List<Week> getWeeks(DateTime now) {
     final week = Week(start: now);

--- a/packages/uni_app/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_api.dart
+++ b/packages/uni_app/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_api.dart
@@ -3,7 +3,6 @@ import 'package:uni/controller/fetchers/schedule_fetcher/schedule_fetcher.dart';
 import 'package:uni/controller/networking/network_router.dart';
 import 'package:uni/controller/parsers/schedule/api/parser.dart';
 import 'package:uni/model/entities/lecture.dart';
-import 'package:uni/model/entities/profile.dart';
 import 'package:uni/model/utils/time/week.dart';
 import 'package:uni/session/flows/base/session.dart';
 
@@ -19,7 +18,7 @@ class ScheduleFetcherApi extends ScheduleFetcher {
 
   /// Fetches the user's lectures from the faculties' API.
   @override
-  Future<List<Lecture>> getLectures(Session session, Profile profile) async {
+  Future<List<Lecture>> getLectures(Session session) async {
     final dates = getDates();
 
     final urls = getEndpoints(session);

--- a/packages/uni_app/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_new_api.dart
+++ b/packages/uni_app/lib/controller/fetchers/schedule_fetcher/schedule_fetcher_new_api.dart
@@ -2,7 +2,6 @@ import 'package:uni/controller/fetchers/schedule_fetcher/schedule_fetcher.dart';
 import 'package:uni/controller/networking/network_router.dart';
 import 'package:uni/controller/parsers/schedule/new_api/parser.dart';
 import 'package:uni/model/entities/lecture.dart';
-import 'package:uni/model/entities/profile.dart';
 import 'package:uni/session/flows/base/session.dart';
 
 /// Class for fetching the user's lectures from the schedule's HTML page.
@@ -17,7 +16,7 @@ class ScheduleFetcherNewApi extends ScheduleFetcher {
 
   /// Fetches the user's lectures from the schedule's HTML page.
   @override
-  Future<List<Lecture>> getLectures(Session session, Profile profile) async {
+  Future<List<Lecture>> getLectures(Session session) async {
     final endpoints = getEndpoints(session);
     final lectiveYear = getLectiveYear(DateTime.now());
 

--- a/packages/uni_app/lib/model/providers/lazy/lecture_provider.dart
+++ b/packages/uni_app/lib/model/providers/lazy/lecture_provider.dart
@@ -5,7 +5,6 @@ import 'package:uni/controller/fetchers/schedule_fetcher/schedule_fetcher_api.da
 import 'package:uni/controller/fetchers/schedule_fetcher/schedule_fetcher_new_api.dart';
 import 'package:uni/controller/local_storage/database/app_lectures_database.dart';
 import 'package:uni/model/entities/lecture.dart';
-import 'package:uni/model/entities/profile.dart';
 import 'package:uni/model/providers/state_provider_notifier.dart';
 import 'package:uni/model/providers/state_providers.dart';
 import 'package:uni/session/flows/base/session.dart';
@@ -23,17 +22,14 @@ class LectureProvider extends StateProviderNotifier<List<Lecture>> {
   Future<List<Lecture>> loadFromRemote(StateProviders stateProviders) async {
     return fetchUserLectures(
       stateProviders.sessionProvider.state!,
-      stateProviders.profileProvider.state!,
     );
   }
 
   Future<List<Lecture>> fetchUserLectures(
-    Session session,
-    Profile profile, {
+    Session session, {
     ScheduleFetcher? fetcher,
   }) async {
-    final lectures =
-        await getLecturesFromFetcherOrElse(fetcher, session, profile);
+    final lectures = await getLecturesFromFetcherOrElse(fetcher, session);
 
     final db = AppLecturesDatabase();
     await db.saveIfPersistentSession(lectures);
@@ -44,11 +40,10 @@ class LectureProvider extends StateProviderNotifier<List<Lecture>> {
   Future<List<Lecture>> getLecturesFromFetcherOrElse(
     ScheduleFetcher? fetcher,
     Session session,
-    Profile profile,
   ) =>
-      fetcher?.getLectures(session) ?? getLectures(session, profile);
+      fetcher?.getLectures(session) ?? getLectures(session);
 
-  Future<List<Lecture>> getLectures(Session session, Profile profile) {
+  Future<List<Lecture>> getLectures(Session session) {
     return ScheduleFetcherApi().getLectures(session).catchError(
           (e) => ScheduleFetcherNewApi().getLectures(session),
         );

--- a/packages/uni_app/lib/model/providers/lazy/lecture_provider.dart
+++ b/packages/uni_app/lib/model/providers/lazy/lecture_provider.dart
@@ -46,11 +46,11 @@ class LectureProvider extends StateProviderNotifier<List<Lecture>> {
     Session session,
     Profile profile,
   ) =>
-      fetcher?.getLectures(session, profile) ?? getLectures(session, profile);
+      fetcher?.getLectures(session) ?? getLectures(session, profile);
 
   Future<List<Lecture>> getLectures(Session session, Profile profile) {
-    return ScheduleFetcherApi().getLectures(session, profile).catchError(
-          (e) => ScheduleFetcherNewApi().getLectures(session, profile),
+    return ScheduleFetcherApi().getLectures(session).catchError(
+          (e) => ScheduleFetcherNewApi().getLectures(session),
         );
   }
 }


### PR DESCRIPTION
Removes all profile references from the lecture provider because it is no longer needed.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
