### PR TITLE
fix: add mobility course name

### DIFF
--- a/packages/uni_app/lib/model/entities/course.dart
+++ b/packages/uni_app/lib/model/entities/course.dart
@@ -27,10 +27,15 @@ class Course {
   });
 
   factory Course.fromJson(Map<String, dynamic> json) {
+    var name = json['cur_nome'] as String?;
+    if (name == null || name.isEmpty) {
+      name = json['fest_tipo_descr'] as String?;
+    }
+
     return Course(
       id: json['cur_id'] as int?,
       festId: json['fest_id'] as int?,
-      name: json['cur_nome'] as String?,
+      name: name,
       abbreviation: json['abbreviation'] as String?,
       currYear: json['ano_curricular'] as String?,
       firstEnrollment: json['fest_a_lect_1_insc'] as int?,


### PR DESCRIPTION
Adds the name of the mobility course.

The response received from the API is as follows:

```json
    {
      "fest_id": *redacted*,
      "fest_tipo": "M",
      "fest_tipo_descr": "Mobilidade",
      "cur_nome": "",
      "fest_a_lect_1_insc": 2024,
      "fest_d_1_insc": "2024-09-11",
      "cur_id": null,
      "est_alectivo": 2025,
      "est_sig": "NI",
      "est_nome": "Não Inscrito",
      "est_d_inicio": "2025-08-01",
      "est_d_fim": "",
      "inst_nome": "Faculdade de Engenharia",
      "inst_sigla": "FEUP",
      "ano_curricular": ""
    }
```

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
