### PR TITLE
fix: unit info error on relogin

### DIFF
--- a/packages/uni_app/lib/model/providers/state_provider_notifier.dart
+++ b/packages/uni_app/lib/model/providers/state_provider_notifier.dart
@@ -16,7 +16,11 @@ abstract class StateProviderNotifier<T> extends ChangeNotifier {
     RequestStatus initialStatus = RequestStatus.busy,
     T? initialState,
   })  : _requestStatus = initialStatus,
+        _initialState = initialState,
         _state = initialState;
+
+  /// The initial state of the model.
+  final T? _initialState;
 
   /// The model that this notifier provides.
   /// This future will throw if the data loading fails.
@@ -68,7 +72,7 @@ abstract class StateProviderNotifier<T> extends ChangeNotifier {
   /// Makes the state null, as if the model has never been loaded,
   /// so that consumers may trigger the loading again.
   void invalidate() {
-    _state = null;
+    _state = _initialState;
     notifyListeners();
   }
 


### PR DESCRIPTION
Fixes an issue where entering the course unit info page after a login results in an error.
Good catch, @Process-ing.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
