### PR TITLE
fix: empty calendar

### DIFF
--- a/packages/uni_app/lib/app_links/uni_app_links.dart
+++ b/packages/uni_app/lib/app_links/uni_app_links.dart
@@ -1,14 +1,9 @@
 import 'dart:async';
 
 import 'package:app_links/app_links.dart';
+import 'package:uni/utils/uri.dart';
 
 final _authUri = Uri(scheme: 'pt.up.fe.ni.uni', host: 'auth');
-
-extension _StripQueryParameters on Uri {
-  Uri stripQueryParameters() {
-    return Uri(scheme: scheme, host: host, path: path);
-  }
-}
 
 class UniAppLinks {
   final login = _AuthenticationAppLink(
@@ -30,7 +25,7 @@ class _AuthenticationAppLink {
     FutureOr<void> Function(Uri redirectUri) callback,
   ) async {
     final interceptedUri = _appLinks.uriLinkStream
-        .firstWhere((uri) => redirectUri == uri.stripQueryParameters());
+        .firstWhere((uri) => redirectUri == uri.stripQueryComponent());
 
     await callback(redirectUri);
     final data = await interceptedUri;

--- a/packages/uni_app/lib/controller/networking/network_router.dart
+++ b/packages/uni_app/lib/controller/networking/network_router.dart
@@ -5,14 +5,11 @@ import 'package:uni/http/client/authenticated.dart';
 import 'package:uni/http/client/timeout.dart';
 import 'package:uni/session/authentication_controller.dart';
 import 'package:uni/session/flows/base/session.dart';
+import 'package:uni/utils/uri.dart';
 
 extension UriString on String {
   /// Converts a [String] to an [Uri].
   Uri toUri() => Uri.parse(this);
-}
-
-extension SigarraUriEncoding on Uri {
-  Uri normalizeQueryComponent() => replace(query: query.replaceAll('+', '%20'));
 }
 
 /// Manages the networking of the app.

--- a/packages/uni_app/lib/controller/networking/network_router.dart
+++ b/packages/uni_app/lib/controller/networking/network_router.dart
@@ -11,6 +11,10 @@ extension UriString on String {
   Uri toUri() => Uri.parse(this);
 }
 
+extension SigarraUriEncoding on Uri {
+  Uri normalizeQueryComponent() => replace(query: query.replaceAll('+', '%20'));
+}
+
 /// Manages the networking of the app.
 class NetworkRouter {
   /// The HTTP client used for all requests.
@@ -65,6 +69,10 @@ class NetworkRouter {
       ];
     }
 
-    return client.get(parsedUrl.replace(queryParameters: allQueryParameters));
+    final requestUri = parsedUrl
+        .replace(queryParameters: allQueryParameters)
+        .normalizeQueryComponent();
+
+    return client.get(requestUri);
   }
 }

--- a/packages/uni_app/lib/utils/uri.dart
+++ b/packages/uni_app/lib/utils/uri.dart
@@ -1,0 +1,16 @@
+extension UriUtils on Uri {
+  Uri stripQueryComponent() {
+    return Uri(
+      scheme: scheme,
+      userInfo: userInfo,
+      host: host,
+      port: port,
+      path: path,
+      fragment: fragment,
+    );
+  }
+
+  Uri normalizeQueryComponent() => query.isNotEmpty
+      ? replace(query: query.replaceAll('+', '%20'))
+      : stripQueryComponent();
+}

--- a/packages/uni_app/lib/utils/uri.dart
+++ b/packages/uni_app/lib/utils/uri.dart
@@ -6,7 +6,7 @@ extension UriUtils on Uri {
       host: host,
       port: port,
       path: path,
-      fragment: fragment,
+      fragment: fragment.isNotEmpty ? fragment : null,
     );
   }
 


### PR DESCRIPTION
Fixes an issue where fetching the calendar returns no events due to a wrong URL, after conversion of %20 to + in Dart's standard lib.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
