### PR TITLE
fix: exams and transport backgrounds

### DIFF
--- a/packages/uni_app/lib/view/bus_stop_next_arrivals/bus_stop_next_arrivals.dart
+++ b/packages/uni_app/lib/view/bus_stop_next_arrivals/bus_stop_next_arrivals.dart
@@ -132,11 +132,9 @@ class NextArrivalsState extends State<NextArrivals> {
             ),
           ),
           constraints: const BoxConstraints(maxHeight: 150),
-          child: Material(
-            child: TabBar(
-              isScrollable: true,
-              tabs: createTabs(queryData),
-            ),
+          child: TabBar(
+            isScrollable: true,
+            tabs: createTabs(queryData),
           ),
         ),
         Expanded(

--- a/packages/uni_app/lib/view/exams/exams.dart
+++ b/packages/uni_app/lib/view/exams/exams.dart
@@ -139,9 +139,7 @@ class ExamsPageViewState extends SecondaryPageViewState<ExamsPageView> {
       key: Key('$exam-exam'),
       margin: const EdgeInsets.fromLTRB(12, 4, 12, 0),
       child: RowContainer(
-        color: isHidden
-            ? Theme.of(context).hintColor
-            : Theme.of(context).scaffoldBackgroundColor,
+        color: isHidden ? Theme.of(context).hintColor : null,
         child: ExamRow(
           exam: exam,
           teacher: '',


### PR DESCRIPTION
Fixes the backgrounds of exam widgets and transport tabs.
This was caused by previous changes to the theme of the app, made in 9caa64ecf9f1f500df691b0db3a46310073700b1.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
