### PR TITLE
refactor: use inheritance for endpoints

### DIFF
--- a/packages/uni_app/lib/session/flows/credentials/request.dart
+++ b/packages/uni_app/lib/session/flows/credentials/request.dart
@@ -73,11 +73,16 @@ class CredentialsSessionRequest extends SessionRequest {
     final api = SigarraApi();
     const tempFaculty = 'feup';
 
-    final loginResponse = await api.authentication.login.call(
-      username: username,
-      password: password,
-      options: FacultyRequestOptions(faculty: tempFaculty, client: httpClient),
-    );
+    final loginResponse = await api.authentication
+        .login(
+          username: username,
+          password: password,
+          options: FacultyRequestOptions(
+            faculty: tempFaculty,
+            client: httpClient,
+          ),
+        )
+        .call();
 
     if (!loginResponse.success) {
       return null;
@@ -98,11 +103,13 @@ class CredentialsSessionRequest extends SessionRequest {
     http.Client httpClient,
   ) async {
     final html = SigarraHtml();
-    final response = await html.authentication.login.call(
-      username: username,
-      password: password,
-      options: FacultyRequestOptions(client: httpClient),
-    );
+    final response = await html.authentication
+        .login(
+          username: username,
+          password: password,
+          options: FacultyRequestOptions(client: httpClient),
+        )
+        .call();
 
     final error = response.asFailed();
     return error.reason;

--- a/packages/uni_app/lib/session/flows/federated/request.dart
+++ b/packages/uni_app/lib/session/flows/federated/request.dart
@@ -58,12 +58,9 @@ class FederatedSessionRequest extends SessionRequest {
     final authorizedClient = credential.createHttpClient(httpClient);
 
     final oidc = SigarraOidc();
-    final response = await oidc.token
-        .call(
-          options: BaseRequestOptions(
-            client: authorizedClient,
-          ),
-        )
+    final response = await oidc
+        .token(options: SigarraRequestOptions(client: authorizedClient))
+        .call()
         .onError<OpenIdException>(_reportExceptionAndFail)
         .onError<HttpRequestException>(_reportExceptionAndFail);
 

--- a/packages/uni_app/lib/sigarra/endpoint.dart
+++ b/packages/uni_app/lib/sigarra/endpoint.dart
@@ -1,0 +1,7 @@
+import 'package:uni/sigarra/response.dart';
+
+abstract class Endpoint<T extends EndpointResponse> {
+  const Endpoint();
+
+  Future<T> call();
+}

--- a/packages/uni_app/lib/sigarra/endpoints/api/authentication/authentication.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/api/authentication/authentication.dart
@@ -1,7 +1,5 @@
 import 'package:uni/sigarra/endpoints/api/authentication/login/login.dart';
-import 'package:uni/utils/lazy.dart';
 
 class SigarraApiAuthentication {
-  final _login = Lazy(() => const Login());
-  Login get login => _login.value;
+  final login = Login.new;
 }

--- a/packages/uni_app/lib/sigarra/endpoints/api/authentication/login/login.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/api/authentication/login/login.dart
@@ -7,14 +7,18 @@ import 'package:uni/sigarra/endpoints/api/authentication/login/response.dart';
 import 'package:uni/sigarra/options.dart';
 
 class Login {
-  const Login();
+  const Login({
+    required this.username,
+    required this.password,
+    this.options,
+  });
 
-  Future<LoginResponse> call({
-    required String username,
-    required String password,
-    required FacultyRequestOptions? options,
-  }) async {
-    options = options ?? FacultyRequestOptions();
+  final String username;
+  final String password;
+  final FacultyRequestOptions? options;
+
+  Future<LoginResponse> call() async {
+    final options = this.options ?? FacultyRequestOptions();
 
     final loginUrl = options.baseUrl.resolve('mob_val_geral.autentica');
 

--- a/packages/uni_app/lib/sigarra/endpoints/api/authentication/login/login.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/api/authentication/login/login.dart
@@ -2,11 +2,12 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 import 'package:uni/http/utils.dart';
+import 'package:uni/sigarra/endpoint.dart';
 import 'package:uni/sigarra/endpoints/api/authentication/login/json.dart';
 import 'package:uni/sigarra/endpoints/api/authentication/login/response.dart';
 import 'package:uni/sigarra/options.dart';
 
-class Login {
+class Login extends Endpoint<LoginResponse> {
   const Login({
     required this.username,
     required this.password,
@@ -17,6 +18,7 @@ class Login {
   final String password;
   final FacultyRequestOptions? options;
 
+  @override
   Future<LoginResponse> call() async {
     final options = this.options ?? FacultyRequestOptions();
 

--- a/packages/uni_app/lib/sigarra/endpoints/api/authentication/login/response.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/api/authentication/login/response.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:uni/sigarra/response.dart';
 
-abstract class LoginResponse extends SigarraResponse {
+abstract class LoginResponse extends EndpointResponse {
   const LoginResponse({required super.success});
 
   LoginSuccessfulResponse asSuccessful() => this as LoginSuccessfulResponse;

--- a/packages/uni_app/lib/sigarra/endpoints/html/authentication/authentication.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/html/authentication/authentication.dart
@@ -1,11 +1,7 @@
 import 'package:uni/sigarra/endpoints/html/authentication/login/login.dart';
 import 'package:uni/sigarra/endpoints/html/authentication/logout/logout.dart';
-import 'package:uni/utils/lazy.dart';
 
 class SigarraHtmlAuthentication {
-  final _logout = Lazy(() => const Logout());
-  Logout get logout => _logout.value;
-
-  final _login = Lazy(() => const Login());
-  Login get login => _login.value;
+  final logout = Logout.new;
+  final login = Login.new;
 }

--- a/packages/uni_app/lib/sigarra/endpoints/html/authentication/login/login.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/html/authentication/login/login.dart
@@ -4,18 +4,24 @@ import 'package:html/dom.dart' as html;
 import 'package:html/parser.dart' as html_parser;
 import 'package:http/http.dart' as http;
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:uni/sigarra/endpoint.dart';
 import 'package:uni/sigarra/endpoints/html/authentication/login/response.dart';
 import 'package:uni/sigarra/options.dart';
 
-class Login {
-  const Login();
+class Login extends Endpoint<LoginResponse> {
+  const Login({
+    required this.username,
+    required this.password,
+    this.options,
+  });
 
-  Future<LoginResponse> call({
-    required String username,
-    required String password,
-    FacultyRequestOptions? options,
-  }) async {
-    options = options ?? FacultyRequestOptions();
+  final String username;
+  final String password;
+  final FacultyRequestOptions? options;
+
+  @override
+  Future<LoginResponse> call() async {
+    final options = this.options ?? FacultyRequestOptions();
 
     final loginUrl = options.baseUrl.resolve('vld_validacao.validacao');
 

--- a/packages/uni_app/lib/sigarra/endpoints/html/authentication/login/response.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/html/authentication/login/response.dart
@@ -1,6 +1,6 @@
 import 'package:uni/sigarra/response.dart';
 
-class LoginResponse extends SigarraResponse {
+class LoginResponse extends EndpointResponse {
   const LoginResponse({required super.success});
 
   LoginFailedResponse asFailed() => this as LoginFailedResponse;

--- a/packages/uni_app/lib/sigarra/endpoints/html/authentication/logout/logout.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/html/authentication/logout/logout.dart
@@ -1,17 +1,21 @@
+import 'package:uni/sigarra/endpoint.dart';
 import 'package:uni/sigarra/options.dart';
 import 'package:uni/sigarra/response.dart';
 
-class Logout {
-  const Logout();
+class Logout extends Endpoint {
+  const Logout({
+    this.options,
+  });
 
-  Future<SigarraResponse> call({
-    FacultyRequestOptions? options,
-  }) async {
-    options = options ?? FacultyRequestOptions();
+  final FacultyRequestOptions? options;
+
+  @override
+  Future<EndpointResponse> call() async {
+    final options = this.options ?? FacultyRequestOptions();
 
     final logoutUrl = options.baseUrl.resolve('vld_validacao.sair');
     final response = await options.client.get(logoutUrl);
 
-    return SigarraResponse(success: response.statusCode == 200);
+    return EndpointResponse(success: response.statusCode == 200);
   }
 }

--- a/packages/uni_app/lib/sigarra/endpoints/oidc/oidc.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/oidc/oidc.dart
@@ -1,7 +1,5 @@
 import 'package:uni/sigarra/endpoints/oidc/token/token.dart';
-import 'package:uni/utils/lazy.dart';
 
 class SigarraOidc {
-  final _token = Lazy(Token.new);
-  Token get token => _token.value;
+  final token = Token.new;
 }

--- a/packages/uni_app/lib/sigarra/endpoints/oidc/token/response.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/oidc/token/response.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:uni/sigarra/response.dart';
 
-class TokenResponse extends SigarraResponse {
+class TokenResponse extends EndpointResponse {
   const TokenResponse({required super.success});
 
   TokenSuccessfulResponse asSuccessful() => this as TokenSuccessfulResponse;

--- a/packages/uni_app/lib/sigarra/endpoints/oidc/token/token.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/oidc/token/token.dart
@@ -1,17 +1,19 @@
 import 'package:uni/http/utils.dart';
+import 'package:uni/sigarra/endpoint.dart';
 import 'package:uni/sigarra/endpoints/oidc/token/response.dart';
 import 'package:uni/sigarra/options.dart';
 
-class Token {
-  const Token();
+class Token extends Endpoint<TokenResponse> {
+  const Token({this.options});
+
+  final SigarraRequestOptions? options;
 
   /// Returns the cookies for SIGARRA using the OIDC token.
   ///
   /// The client must be authorized to make this request.
-  Future<TokenResponse> call({
-    BaseRequestOptions? options,
-  }) async {
-    options = options ?? BaseRequestOptions();
+  @override
+  Future<TokenResponse> call() async {
+    final options = this.options ?? SigarraRequestOptions();
 
     final tokenUrl = options.baseUrl.resolve('auth/oidc/token');
     final response = await options.client.get(

--- a/packages/uni_app/lib/sigarra/options.dart
+++ b/packages/uni_app/lib/sigarra/options.dart
@@ -1,22 +1,34 @@
 import 'package:http/http.dart' as http;
 
-class BaseRequestOptions {
+abstract class BaseRequestOptions {
   BaseRequestOptions({http.Client? client}) : client = client ?? http.Client();
 
   final http.Client client;
 
-  Uri get baseUrl => Uri(scheme: 'https', host: 'sigarra.up.pt');
+  Uri get baseUrl;
 
   BaseRequestOptions copyWith({
     http.Client? client,
+  });
+}
+
+class SigarraRequestOptions extends BaseRequestOptions {
+  SigarraRequestOptions({super.client});
+
+  @override
+  Uri get baseUrl => Uri(scheme: 'https', host: 'sigarra.up.pt');
+
+  @override
+  SigarraRequestOptions copyWith({
+    http.Client? client,
   }) {
-    return BaseRequestOptions(
+    return SigarraRequestOptions(
       client: client ?? this.client,
     );
   }
 }
 
-class FacultyRequestOptions extends BaseRequestOptions {
+class FacultyRequestOptions extends SigarraRequestOptions {
   FacultyRequestOptions({
     this.faculty = 'up',
     this.language = 'pt',

--- a/packages/uni_app/lib/sigarra/response.dart
+++ b/packages/uni_app/lib/sigarra/response.dart
@@ -1,5 +1,5 @@
-class SigarraResponse {
-  const SigarraResponse({required this.success});
+class EndpointResponse {
+  const EndpointResponse({required this.success});
 
   final bool success;
 }


### PR DESCRIPTION
Refactors the endpoints to use inheritance. Useful to enforce a specific structure for all endpoints, as well as having functions that accept a generic `Endpoint<T>`.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
