### PR TITLE
feat: added mapper function to LazyConsumer

### DIFF
--- a/packages/uni_app/lib/view/home/widgets/schedule_card.dart
+++ b/packages/uni_app/lib/view/home/widgets/schedule_card.dart
@@ -10,7 +10,6 @@ import 'package:uni/model/utils/time/week.dart';
 import 'package:uni/utils/navigation_items.dart';
 import 'package:uni/view/common_widgets/date_rectangle.dart';
 import 'package:uni/view/common_widgets/generic_card.dart';
-import 'package:uni/view/exams/exams.dart';
 import 'package:uni/view/home/widgets/schedule_card_shimmer.dart';
 import 'package:uni/view/lazy_consumer.dart';
 import 'package:uni/view/locale_notifier.dart';
@@ -50,7 +49,7 @@ class ScheduleCard extends GenericCard {
         ),
       ),
       contentLoadingWidget: const ScheduleCardShimmer().build(context),
-      mapper: (lectures) => lectures
+      mapper: (lectures) => (lectures as List<Lecture>)
           .where(
             (lecture) =>
                 lecture.endTime.isAfter(DateTime.now()) ||

--- a/packages/uni_app/lib/view/home/widgets/schedule_card.dart
+++ b/packages/uni_app/lib/view/home/widgets/schedule_card.dart
@@ -49,7 +49,7 @@ class ScheduleCard extends GenericCard {
         ),
       ),
       contentLoadingWidget: const ScheduleCardShimmer().build(context),
-      mapper: (lectures) => (lectures as List<Lecture>)
+      mapper: (lectures) => lectures
           .where((lecture) => lecture.endTime.isAfter(DateTime.now()))
           .toList(),
     );

--- a/packages/uni_app/lib/view/home/widgets/schedule_card.dart
+++ b/packages/uni_app/lib/view/home/widgets/schedule_card.dart
@@ -50,11 +50,7 @@ class ScheduleCard extends GenericCard {
       ),
       contentLoadingWidget: const ScheduleCardShimmer().build(context),
       mapper: (lectures) => (lectures as List<Lecture>)
-          .where(
-            (lecture) =>
-                lecture.endTime.isAfter(DateTime.now()) ||
-                lecture.startTime.weekday != DateTime.now().weekday,
-          )
+          .where((lecture) => lecture.endTime.isAfter(DateTime.now()))
           .toList(),
     );
   }

--- a/packages/uni_app/lib/view/home/widgets/schedule_card.dart
+++ b/packages/uni_app/lib/view/home/widgets/schedule_card.dart
@@ -49,6 +49,9 @@ class ScheduleCard extends GenericCard {
         ),
       ),
       contentLoadingWidget: const ScheduleCardShimmer().build(context),
+      mapper: (lectures) => lectures
+          .where((lecture) => lecture.endTime.compareTo(DateTime.now()) > 0)
+          .toList(),
     );
   }
 

--- a/packages/uni_app/lib/view/home/widgets/schedule_card.dart
+++ b/packages/uni_app/lib/view/home/widgets/schedule_card.dart
@@ -10,6 +10,7 @@ import 'package:uni/model/utils/time/week.dart';
 import 'package:uni/utils/navigation_items.dart';
 import 'package:uni/view/common_widgets/date_rectangle.dart';
 import 'package:uni/view/common_widgets/generic_card.dart';
+import 'package:uni/view/exams/exams.dart';
 import 'package:uni/view/home/widgets/schedule_card_shimmer.dart';
 import 'package:uni/view/lazy_consumer.dart';
 import 'package:uni/view/locale_notifier.dart';
@@ -50,7 +51,11 @@ class ScheduleCard extends GenericCard {
       ),
       contentLoadingWidget: const ScheduleCardShimmer().build(context),
       mapper: (lectures) => lectures
-          .where((lecture) => lecture.endTime.compareTo(DateTime.now()) > 0)
+          .where(
+            (lecture) =>
+                lecture.endTime.isAfter(DateTime.now()) ||
+                lecture.startTime.weekday != DateTime.now().weekday,
+          )
           .toList(),
     );
   }
@@ -74,16 +79,8 @@ class ScheduleCard extends GenericCard {
     for (final dayLectures
         in lecturesByDay.sublist(0, min(2, lecturesByDay.length))) {
       final day = dayLectures.key;
-      final lectures = dayLectures.value
-          .where(
-            (element) =>
-                // Hide finished lectures from today
-                element.startTime.weekday != DateTime.now().weekday ||
-                element.endTime.isAfter(DateTime.now()),
-          )
-          .toList();
 
-      if (lectures.isEmpty) {
+      if (dayLectures.value.isEmpty) {
         continue;
       }
 
@@ -94,11 +91,11 @@ class ScheduleCard extends GenericCard {
         ),
       );
 
-      for (final lecture in lectures) {
+      for (final lecture in dayLectures.value) {
         rows.add(createRowFromLecture(context, lecture));
       }
 
-      if (lectures.length >= 2) {
+      if (dayLectures.value.length >= 2) {
         break;
       }
     }

--- a/packages/uni_app/lib/view/lazy_consumer.dart
+++ b/packages/uni_app/lib/view/lazy_consumer.dart
@@ -28,6 +28,7 @@ class LazyConsumer<T1 extends StateProviderNotifier<T2>, T2>
     required this.hasContent,
     required this.onNullContent,
     this.contentLoadingWidget,
+    this.mapper,
     super.key,
   });
 
@@ -35,6 +36,9 @@ class LazyConsumer<T1 extends StateProviderNotifier<T2>, T2>
   final bool Function(T2) hasContent;
   final Widget onNullContent;
   final Widget? contentLoadingWidget;
+  final T2 Function(T2)? mapper;
+
+  static T2 _defaultMapper<T2>(T2 value) => value;
 
   @override
   Widget build(BuildContext context) {
@@ -89,8 +93,10 @@ class LazyConsumer<T1 extends StateProviderNotifier<T2>, T2>
   }
 
   Widget requestDependantWidget(BuildContext context, T1 provider) {
-    final showContent =
-        provider.state != null && hasContent(provider.state as T2);
+    final mappedState = provider.state != null
+        ? (mapper ?? _defaultMapper)(provider.state as T2)
+        : null;
+    final showContent = provider.state != null && hasContent(mappedState as T2);
 
     if (provider.requestStatus == RequestStatus.busy && !showContent) {
       return loadingWidget(context);
@@ -99,7 +105,7 @@ class LazyConsumer<T1 extends StateProviderNotifier<T2>, T2>
     }
 
     return showContent
-        ? builder(context, provider.state as T2)
+        ? builder(context, mappedState)
         : Center(
             child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 10),

--- a/packages/uni_app/lib/view/lazy_consumer.dart
+++ b/packages/uni_app/lib/view/lazy_consumer.dart
@@ -36,9 +36,9 @@ class LazyConsumer<T1 extends StateProviderNotifier<T2>, T2>
   final bool Function(T2) hasContent;
   final Widget onNullContent;
   final Widget? contentLoadingWidget;
-  final T2 Function(dynamic)? mapper;
+  final T2 Function(T2)? mapper;
 
-  static T2 _defaultMapper<T2>(dynamic value) => value as T2;
+  static T2 _defaultMapper<T2>(T2 value) => value;
 
   @override
   Widget build(BuildContext context) {
@@ -94,7 +94,7 @@ class LazyConsumer<T1 extends StateProviderNotifier<T2>, T2>
 
   Widget requestDependantWidget(BuildContext context, T1 provider) {
     final mappedState = provider.state != null
-        ? (mapper ?? _defaultMapper)(provider.state as dynamic)
+        ? (mapper ?? _defaultMapper)(provider.state as T2)
         : null;
 
     final showContent = provider.state != null && hasContent(mappedState as T2);

--- a/packages/uni_app/lib/view/lazy_consumer.dart
+++ b/packages/uni_app/lib/view/lazy_consumer.dart
@@ -36,9 +36,9 @@ class LazyConsumer<T1 extends StateProviderNotifier<T2>, T2>
   final bool Function(T2) hasContent;
   final Widget onNullContent;
   final Widget? contentLoadingWidget;
-  final T2 Function(T2)? mapper;
+  final T2 Function(dynamic)? mapper;
 
-  static T2 _defaultMapper<T2>(T2 value) => value;
+  static T2 _defaultMapper<T2>(dynamic value) => value as T2;
 
   @override
   Widget build(BuildContext context) {
@@ -94,8 +94,9 @@ class LazyConsumer<T1 extends StateProviderNotifier<T2>, T2>
 
   Widget requestDependantWidget(BuildContext context, T1 provider) {
     final mappedState = provider.state != null
-        ? (mapper ?? _defaultMapper)(provider.state as T2)
+        ? (mapper ?? _defaultMapper)(provider.state as dynamic)
         : null;
+
     final showContent = provider.state != null && hasContent(mappedState as T2);
 
     if (provider.requestStatus == RequestStatus.busy && !showContent) {


### PR DESCRIPTION
Closes #1238 
1. Changed `LazyConsumer` to use a mapper function that, by default, returns the value itself.
2. Implemented a mapper function on `schedule_card` to filter out classes that have already ended.

Before this fix, if there were no more classes scheduled, but the student had a class that day (thus the schedule wasn't empty), the `schedule_card` did not show any content. Now, it shows "No classes to present":
| Before | After |
|--------|--------|
| ![Screenshot_2024-10-31-01-37-18-246_pt up fe ni uni](https://github.com/user-attachments/assets/f8e4b5e5-fdcf-493d-a651-09535e7106d3) | ![Screenshot_2024-10-31-01-31-28-409_pt up fe ni uni](https://github.com/user-attachments/assets/6773b7a7-5264-464b-9a62-d011a2e27f2c) |

To test, change the `lecture_provider` to return a list with a class on the current day that has already ended, for example:
```dart
Future<List<Lecture>> fetchUserLectures(
  Session session, {
  ScheduleFetcher? fetcher,
}) async {
  final lectures = await getLecturesFromFetcherOrElse(fetcher, session);

  final db = AppLecturesDatabase();
  await db.saveIfPersistentSession(lectures);

  return [
    Lecture(
      'TEST',
      'TP',
      DateTime.parse('2024-10-31 00:30'),
      DateTime.parse('2024-10-31 01:00'),
      'B003',
      'PNFRCD',
      '1LEIC01',
      1,
    ),
  ];
}
```

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
