### PR TITLE
fix: no exams in mobility

### DIFF
--- a/packages/uni_app/lib/controller/fetchers/exam_fetcher.dart
+++ b/packages/uni_app/lib/controller/fetchers/exam_fetcher.dart
@@ -29,7 +29,7 @@ class ExamFetcher implements SessionDependantFetcher {
       if (course.id == null) {
         continue;
       }
-      
+
       for (final url in urls) {
         final currentCourseExams = await parserExams.parseExams(
           await NetworkRouter.getWithCookies(

--- a/packages/uni_app/lib/controller/fetchers/exam_fetcher.dart
+++ b/packages/uni_app/lib/controller/fetchers/exam_fetcher.dart
@@ -26,6 +26,10 @@ class ExamFetcher implements SessionDependantFetcher {
     var courseExams = <Exam>{};
     final urls = getEndpoints(session);
     for (final course in courses) {
+      if (course.id == null) {
+        continue;
+      }
+      
       for (final url in urls) {
         final currentCourseExams = await parserExams.parseExams(
           await NetworkRouter.getWithCookies(

--- a/packages/uni_app/lib/controller/local_storage/database/app_courses_database.dart
+++ b/packages/uni_app/lib/controller/local_storage/database/app_courses_database.dart
@@ -24,7 +24,7 @@ class AppCoursesDatabase extends AppDatabase<List<Course>> {
     // Convert the List<Map<String, dynamic> into a List<Course>.
     return List.generate(maps.length, (i) {
       return Course(
-        id: maps[i]['cur_id'] as int? ?? 0,
+        id: maps[i]['cur_id'] as int?,
         festId: maps[i]['fest_id'] as int? ?? 0,
         name: maps[i]['cur_nome'] as String?,
         abbreviation: maps[i]['abbreviation'] as String?,

--- a/packages/uni_app/lib/controller/parsers/parser_courses.dart
+++ b/packages/uni_app/lib/controller/parsers/parser_courses.dart
@@ -39,7 +39,7 @@ List<Course> _parseCourses(http.Response response) {
     courses.add(
       Course(
         faculty: faculty,
-        id: int.parse(courseId ?? '0'),
+        id: courseId != null ? int.parse(courseId) : null,
         state: courseState,
         name: courseName ?? '',
         festId: int.parse(courseFestId ?? '0'),
@@ -66,7 +66,7 @@ List<Course> _parseCourses(http.Response response) {
       Course(
         firstEnrollment: int.parse(courseFirstEnrollment),
         faculty: faculty,
-        id: int.parse(courseId ?? '0'),
+        id: courseId != null ? int.parse(courseId) : null,
         state: courseState,
         name: courseName ?? '',
         festId: int.parse(courseFestId ?? '0'),


### PR DESCRIPTION
This PR makes it so uni doesn't try to fetch exams for students with the mobility course or other courses with a null id.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
