### PR TITLE
fix: app halting after installation

### DIFF
--- a/packages/uni_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/uni_app/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:usesCleartextTraffic="true"
-        android:allowBackup="true"
+        android:allowBackup="false"
     >
         <activity
             android:name=".MainActivity"

--- a/packages/uni_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/uni_app/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
-   <application
+    <application
         android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        android:allowBackup="true"
+    >
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
This fixes an issue on Android where, after being reinstalled, the uni app will not open, until its data is cleared.

My current hypothesis is that this is happening because, upon reinstallation, the Android system restores the app files from a backup. This is causing some incompatibility with the secure shared preferences or something of sorts.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
