### PR TITLE
Update fetchSheet to work with multiple endpoints

### DIFF
--- a/packages/uni_app/lib/controller/fetchers/course_units_fetcher/course_units_info_fetcher.dart
+++ b/packages/uni_app/lib/controller/fetchers/course_units_fetcher/course_units_info_fetcher.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:html/parser.dart';
 import 'package:uni/controller/fetchers/session_dependant_fetcher.dart';
 import 'package:uni/controller/networking/network_router.dart';
@@ -32,14 +33,34 @@ class CourseUnitsInfoFetcher implements SessionDependantFetcher {
     Session session,
     int occurId,
   ) async {
-    final url = '${getEndpoints(session)[0]}mob_ucurr_geral.perfil';
-    final response = await NetworkRouter.getWithCookies(
-      url,
-      {'pv_ocorrencia_id': occurId.toString()},
-      session,
+    for (final endpoint in getEndpoints(session)) {
+      final url = '$endpoint' 'mob_ucurr_geral.perfil';
+      try {
+        final response = await NetworkRouter.getWithCookies(
+          url,
+          {'pv_ocorrencia_id': occurId.toString()},
+          session,
+        );
+
+        final json = jsonDecode(response.body) as Map<String, dynamic>;
+        if (response != null && json['lingua'] != null) {
+          return parseSheet(response);
+        }
+      } catch (_) {
+        continue;
+      }
+    }
+
+    return Sheet(
+      professors: [],
+      regents: [],
+      content: '',
+      evaluation: '',
+      books: [],
     );
-    return parseSheet(response);
   }
+
+
 
   Future<List<CourseUnitFileDirectory>> fetchCourseUnitFiles(
     Session session,

--- a/packages/uni_app/lib/controller/fetchers/course_units_fetcher/course_units_info_fetcher.dart
+++ b/packages/uni_app/lib/controller/fetchers/course_units_fetcher/course_units_info_fetcher.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'package:html/parser.dart';
 import 'package:http/http.dart';
 import 'package:uni/controller/fetchers/session_dependant_fetcher.dart';
@@ -6,7 +5,6 @@ import 'package:uni/controller/networking/network_router.dart';
 import 'package:uni/controller/parsers/parser_course_unit_info.dart';
 import 'package:uni/model/entities/course_units/course_unit_class.dart';
 import 'package:uni/model/entities/course_units/course_unit_directory.dart';
-import 'package:uni/model/entities/course_units/course_unit_sheet.dart';
 import 'package:uni/model/entities/course_units/sheet.dart';
 import 'package:uni/session/flows/base/session.dart';
 

--- a/packages/uni_app/lib/controller/fetchers/course_units_fetcher/course_units_info_fetcher.dart
+++ b/packages/uni_app/lib/controller/fetchers/course_units_fetcher/course_units_info_fetcher.dart
@@ -26,15 +26,17 @@ class CourseUnitsInfoFetcher implements SessionDependantFetcher {
               url,
               {'pv_ocorrencia_id': occurId.toString()},
               session,
-            ),
+            ).catchError((_) => Response('', 500)),
           ),
     );
 
-    final bestResponse = responses.fold<Response?>(
-      null,
-      (best, current) =>
-          current.body.length > (best?.body.length ?? 0) ? current : best,
-    );
+    final bestResponse = responses
+        .where((response) => response.statusCode == 200)
+        .fold<Response?>(
+          null,
+          (best, current) =>
+              current.body.length > (best?.body.length ?? 0) ? current : best,
+        );
 
     return bestResponse != null
         ? parseSheet(bestResponse)

--- a/packages/uni_app/lib/controller/fetchers/course_units_fetcher/course_units_info_fetcher.dart
+++ b/packages/uni_app/lib/controller/fetchers/course_units_fetcher/course_units_info_fetcher.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:html/parser.dart';
+import 'package:http/http.dart';
 import 'package:uni/controller/fetchers/session_dependant_fetcher.dart';
 import 'package:uni/controller/networking/network_router.dart';
 import 'package:uni/controller/parsers/parser_course_unit_info.dart';
@@ -33,6 +34,10 @@ class CourseUnitsInfoFetcher implements SessionDependantFetcher {
     Session session,
     int occurId,
   ) async {
+    Response? bestResponse;
+    int bestResponseSize = -1;
+
+
     for (final endpoint in getEndpoints(session)) {
       final url = '$endpoint' 'mob_ucurr_geral.perfil';
       try {
@@ -42,13 +47,17 @@ class CourseUnitsInfoFetcher implements SessionDependantFetcher {
           session,
         );
 
-        final json = jsonDecode(response.body) as Map<String, dynamic>;
-        if (response != null && json['lingua'] != null) {
-          return parseSheet(response);
+        if (response.body.length > bestResponseSize) {
+          bestResponseSize = response.body.length;
+          bestResponse = response;
         }
       } catch (_) {
         continue;
       }
+    }
+
+    if (bestResponse != null) {
+      return parseSheet(bestResponse);
     }
 
     return Sheet(
@@ -59,8 +68,6 @@ class CourseUnitsInfoFetcher implements SessionDependantFetcher {
       books: [],
     );
   }
-
-
 
   Future<List<CourseUnitFileDirectory>> fetchCourseUnitFiles(
     Session session,

--- a/packages/uni_app/lib/controller/fetchers/course_units_fetcher/course_units_info_fetcher.dart
+++ b/packages/uni_app/lib/controller/fetchers/course_units_fetcher/course_units_info_fetcher.dart
@@ -16,27 +16,11 @@ class CourseUnitsInfoFetcher implements SessionDependantFetcher {
     return NetworkRouter.getBaseUrlsFromSession(session).toList();
   }
 
-  Future<CourseUnitSheet> fetchCourseUnitSheet(
-    Session session,
-    int occurrId,
-  ) async {
-    // if course unit is not from the main faculty, Sigarra redirects
-    final url = '${getEndpoints(session)[0]}ucurr_geral.ficha_uc_view';
-    final response = await NetworkRouter.getWithCookies(
-      url,
-      {'pv_ocorrencia_id': occurrId.toString()},
-      session,
-    );
-    return parseCourseUnitSheet(response);
-  }
-
   Future<Sheet> fetchSheet(
     Session session,
     int occurId,
   ) async {
     Response? bestResponse;
-    int bestResponseSize = -1;
-
 
     for (final endpoint in getEndpoints(session)) {
       final url = '$endpoint' 'mob_ucurr_geral.perfil';
@@ -47,8 +31,8 @@ class CourseUnitsInfoFetcher implements SessionDependantFetcher {
           session,
         );
 
-        if (response.body.length > bestResponseSize) {
-          bestResponseSize = response.body.length;
+        if (bestResponse == null ||
+            response.body.length > bestResponse.body.length) {
           bestResponse = response;
         }
       } catch (_) {
@@ -56,17 +40,15 @@ class CourseUnitsInfoFetcher implements SessionDependantFetcher {
       }
     }
 
-    if (bestResponse != null) {
-      return parseSheet(bestResponse);
-    }
-
-    return Sheet(
-      professors: [],
-      regents: [],
-      content: '',
-      evaluation: '',
-      books: [],
-    );
+    return bestResponse != null
+        ? parseSheet(bestResponse)
+        : Sheet(
+            professors: [],
+            regents: [],
+            content: '',
+            evaluation: '',
+            books: [],
+          );
   }
 
   Future<List<CourseUnitFileDirectory>> fetchCourseUnitFiles(

--- a/packages/uni_ui/lib/timeline/timeline.dart
+++ b/packages/uni_ui/lib/timeline/timeline.dart
@@ -129,7 +129,7 @@ class _TimelineState extends State<Timeline> {
           child: ScrollablePositionedList.builder(
             itemCount: widget.content.length,
             itemScrollController: _itemScrollController,
-              itemPositionsListener: _itemPositionsListener,
+            itemPositionsListener: _itemPositionsListener,
             itemBuilder: (context, index) {
               return widget.content[index];
             },


### PR DESCRIPTION
Closes #[issue number]

Because my master includes courses from different faculties, I encountered trouble viewing courses from FCUP.  

The issue occurs in the `fetchSheet` function because we only check the first endpoint. 
To address this, I modified the code to traverse the endpoints and check for the presence of the `language` field in the response. This solution works but feels a bit clunky, if anyone has a better aproach, i'd   greatly appreciate your input. I had to check for the field `language` because even when querying the wrong endpoint, we still receive a success response.   


#### Screenshots (Before and After):  

<div align="center">
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/77e1c8ed-2967-40cf-9ddc-72e4d286be54" alt="Before" height="600px"></td>
    <td><img src="https://github.com/user-attachments/assets/2ef03668-1840-44ae-a3c6-c5d7f20a97e7" alt="After" height="600px"></td>
  </tr>
</table>
</div>

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
