### PR TITLE
Added openLibrary API

### DIFF
--- a/packages/uni_app/lib/controller/fetchers/book_fetcher.dart
+++ b/packages/uni_app/lib/controller/fetchers/book_fetcher.dart
@@ -1,26 +1,81 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:uni/controller/networking/network_router.dart';
 
 class BookThumbFetcher {
-  Future<String> fetchBookThumb(String isbn) async {
-    final url = Uri.https(
+  Future<String?> fetchBookThumb(String isbn) async {
+    final googleBooksFuture = _fetchFromGoogleBooks(isbn);
+    final openLibraryFuture = _fetchFromOpenLibrary(isbn);
+
+    final completer = Completer<String?>();
+
+    googleBooksFuture.then((result) {
+      if (result != null && !completer.isCompleted) {
+        completer.complete(result);
+      }
+    });
+
+    openLibraryFuture.then((result) {
+      if (result != null && !completer.isCompleted) {
+        completer.complete(result);
+      }
+    });
+
+    Future.wait([googleBooksFuture, openLibraryFuture]).then((results) {
+      if (!completer.isCompleted) {
+        completer.complete(null);
+      }
+    });
+
+    return completer.future;
+  }
+
+  Future<String?> _fetchFromGoogleBooks(String isbn) async {
+    final googleBooksUrl = Uri.https(
       'www.googleapis.com',
       '/books/v1/volumes',
-      {'q': '+isbn:$isbn'},
+      {'q': 'isbn:$isbn'},
     );
 
     final response =
-        await http.get(Uri.decodeComponent(url.toString()).toUri());
+        await http.get(Uri.decodeComponent(googleBooksUrl.toString()).toUri());
 
-    final bookInformation = ((json.decode(response.body)
-            as Map<String, dynamic>)['items'] as List<dynamic>)
-        .first as Map<String, dynamic>;
+    final numBooks = ((json.decode(response.body)
+            as Map<String, dynamic>)['totalItems'] as int)
+        .toInt();
 
-    final thumbnailURL =
-        ((bookInformation['volumeInfo'] as Map<String, dynamic>)['imageLinks']
-            as Map<String, dynamic>)['thumbnail'];
+    if (numBooks > 0) {
+      final bookInformation = ((json.decode(response.body)
+              as Map<String, dynamic>)['items'] as List<dynamic>)
+          .first as Map<String, dynamic>;
+      final thumbnailURL =
+          ((bookInformation['volumeInfo'] as Map<String, dynamic>)['imageLinks']
+              as Map<String, dynamic>)['thumbnail'];
+      return thumbnailURL.toString();
+    }
 
-    return thumbnailURL.toString();
+    return null;
+  }
+
+  Future<String?> _fetchFromOpenLibrary(String isbn) async {
+    final url = Uri.https('covers.openlibrary.org', '/b/isbn/$isbn-M.jpg');
+
+    try {
+      final response = await http.get(url);
+
+      if (response.statusCode == 200) {
+        final contentType = response.headers['content-type'];
+        if (contentType != null && contentType.startsWith('image/')) {
+          return url.toString();
+        } else {
+          return null;
+        }
+      } else {
+        return null;
+      }
+    } catch (e) {
+      return null;
+    }
   }
 }

--- a/packages/uni_app/lib/view/course_unit_info/widgets/course_unit_sheet.dart
+++ b/packages/uni_app/lib/view/course_unit_info/widgets/course_unit_sheet.dart
@@ -176,46 +176,48 @@ Widget buildExpandedProfessors(
 }
 
 Widget buildBooksRow(BuildContext context, List<Book> books) {
-  return SizedBox(
-    height: 500,
-    width: double.infinity,
-    child: Wrap(
-      alignment: WrapAlignment.spaceBetween,
-      children: [
-        ...books.asMap().entries.map((book) {
-          return FutureBuilder<String?>(
-            builder: (context, snapshot) {
-              return Padding(
-                padding: const EdgeInsets.only(left: 15, right: 15, top: 10),
-                child: Column(
-                  children: [
-                    SizedBox(
-                      width: 135,
-                      height: 140, // adjust this value as needed
-                      child: snapshot.data != null
-                          ? Image(image: NetworkImage(snapshot.data!))
-                          : const Image(
-                              image: AssetImage(
-                                'assets/images/book_placeholder.png',
-                              ),
+  return Wrap(
+    alignment: WrapAlignment.spaceBetween,
+    children: books.map((book) {
+      return Padding(
+        padding: const EdgeInsets.only(left: 15, right: 15, top: 10),
+        child: Column(
+          children: [
+            SizedBox(
+              width: 135,
+              height: 140,
+              child: book.isbn.isNotEmpty
+                  ? FutureBuilder<String?>(
+                      future: BookThumbFetcher().fetchBookThumb(book.isbn),
+                      builder: (context, snapshot) {
+                        if (snapshot.hasData && snapshot.data != null) {
+                          return Image(image: NetworkImage(snapshot.data!));
+                        } else {
+                          return const Image(
+                            image: AssetImage(
+                              'assets/images/book_placeholder.png',
                             ),
-                    ),
-                    SizedBox(
-                      width: 135,
-                      child: Text(
-                        book.value.title,
-                        textAlign: TextAlign.center,
+                          );
+                        }
+                      },
+                    )
+                  : const Image(
+                      image: AssetImage(
+                        'assets/images/book_placeholder.png',
                       ),
                     ),
-                  ],
-                ),
-              );
-            },
-            future: BookThumbFetcher().fetchBookThumb(book.value.isbn),
-          );
-        }),
-      ],
-    ),
+            ),
+            SizedBox(
+              width: 135,
+              child: Text(
+                book.title,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
+      );
+    }).toList(),
   );
 }
 


### PR DESCRIPTION
Closes #[1436]

Added a second API openLibrary to the book fetcher. 

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/c557ae06-0c3f-47c7-bf4e-53cf792e6732" alt="Screenshot 2" width="400"></td>
    <td><img src="https://github.com/user-attachments/assets/01154a36-859d-45e2-8345-9129bfeccd2b" alt="Screenshot 1" width="400"></td>
  </tr>
</table>

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
