### PR TITLE
Refactor/uni icon name

### DIFF
--- a/packages/uni_app/lib/view/home/home.dart
+++ b/packages/uni_app/lib/view/home/home.dart
@@ -8,7 +8,7 @@ import 'package:uni/view/common_widgets/pages_layouts/general/widgets/profile_bu
 import 'package:uni/view/common_widgets/pages_layouts/general/widgets/top_navigation_bar.dart';
 import 'package:uni/view/home/widgets/main_cards_list.dart';
 import 'package:uni/view/home/widgets/tracking_banner.dart';
-import 'package:uni/view/home/widgets/uni_icon.dart';
+import 'package:uni/view/home/widgets/uni_logo.dart';
 
 class HomePageView extends StatefulWidget {
   const HomePageView({super.key});
@@ -130,7 +130,7 @@ class HomePageViewState extends GeneralPageViewState {
     return const AppTopNavbar(
       leftButton: Padding(
         padding: EdgeInsets.symmetric(horizontal: 8),
-        child: UniIcon(),
+        child: UniLogo(),
       ),
       rightButton: ProfileButton(),
     );

--- a/packages/uni_app/lib/view/home/widgets/uni_logo.dart
+++ b/packages/uni_app/lib/view/home/widgets/uni_logo.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
-class UniIcon extends StatelessWidget {
-  const UniIcon({super.key});
+class UniLogo extends StatelessWidget {
+  const UniLogo({super.key});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Closes #1450 
Changed the name of the file uni_icon.dart to uni_logo.dart. Also changed the name of the method to UniLogo

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
