### PR TITLE
Fix for the navigation bar appearing above content.

### DIFF
--- a/packages/uni_app/lib/main.dart
+++ b/packages/uni_app/lib/main.dart
@@ -73,19 +73,10 @@ Future<String> firstRoute() async {
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await SystemChrome.setEnabledSystemUIMode(
-    SystemUiMode.immersiveSticky,
-    overlays: [
-      SystemUiOverlay.top,
-      SystemUiOverlay.bottom,
-    ],
-  );
   SystemChrome.setSystemUIOverlayStyle(
     const SystemUiOverlayStyle(
       statusBarColor: Colors.transparent,
       statusBarIconBrightness: Brightness.light,
-      systemNavigationBarColor: Colors.transparent,
-      systemNavigationBarIconBrightness: Brightness.light,
     ),
   );
 


### PR DESCRIPTION
A potential fix for the navigation bar overlapping content. It's an idea. I disabled the transparency (it is now black), so the app content appears above it.

<img width="300" src="https://github.com/user-attachments/assets/7e1a9a03-0aaf-459e-8b61-68b642d3ced6">