### PR TITLE
fix: Library card size

### DIFF
--- a/packages/uni_ui/lib/cards/library_occupation_card.dart
+++ b/packages/uni_ui/lib/cards/library_occupation_card.dart
@@ -20,7 +20,7 @@ class FloorOccupationWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(vertical: 5),
+      padding: const EdgeInsets.symmetric(vertical: 4),
       child: Column(
         children: [
           Row(
@@ -66,12 +66,12 @@ class LibraryOccupationCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return GenericCard(
       key: key,
-      padding: const EdgeInsets.symmetric(vertical: 25, horizontal: 15),
+      padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 10),
       tooltip: '',
       child: Row(
         children: [
           CircularPercentIndicator(
-            radius: 100,
+            radius: 90,
             lineWidth: 12,
             percent: occupation / capacity,
             center: Text(
@@ -82,7 +82,7 @@ class LibraryOccupationCard extends StatelessWidget {
             backgroundColor: Theme.of(context).colorScheme.surface,
             progressColor: Theme.of(context).primaryColor,
           ),
-          const SizedBox(width: 20),
+          const SizedBox(width: 10),
           Expanded(
             child: Column(
               children: occupationWidgetsList,

--- a/packages/uni_ui/lib/cards/library_occupation_card.dart
+++ b/packages/uni_ui/lib/cards/library_occupation_card.dart
@@ -20,7 +20,7 @@ class FloorOccupationWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(vertical: 4),
+      padding: const EdgeInsets.symmetric(vertical: 3),
       child: Column(
         children: [
           Row(
@@ -39,7 +39,7 @@ class FloorOccupationWidget extends StatelessWidget {
           LinearPercentIndicator(
             lineHeight: 8.0,
             percent: occupation / capacity,
-            backgroundColor: Theme.of(context).colorScheme.surface,
+            backgroundColor: const Color.fromRGBO(177, 77, 84, 0.25),
             progressColor: Theme.of(context).primaryColor,
             barRadius: const Radius.circular(10),
             padding: EdgeInsets.zero,
@@ -79,7 +79,7 @@ class LibraryOccupationCard extends StatelessWidget {
               style: Theme.of(context).textTheme.displayMedium,
             ),
             circularStrokeCap: CircularStrokeCap.round,
-            backgroundColor: Theme.of(context).colorScheme.surface,
+            backgroundColor: const Color.fromRGBO(177, 77, 84, 0.25),
             progressColor: Theme.of(context).primaryColor,
           ),
           const SizedBox(width: 10),


### PR DESCRIPTION
Closes #1474
Fixes the issue regarding the weird size/shape of the library card when inserted at the home and faculty pages.

## Homepage preview:
<div>
    <img src=https://github.com/user-attachments/assets/5697b8b8-8ef3-4cc7-a3d0-7ec5ab1578a8 width=250>
</div>


# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
