### PR TITLE
feat: save lectures to device calendar

### DIFF
--- a/packages/uni_app/lib/utils/calendar_service.dart
+++ b/packages/uni_app/lib/utils/calendar_service.dart
@@ -1,0 +1,53 @@
+import 'package:device_calendar/device_calendar.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:timezone/timezone.dart' as tz;
+import 'package:uni/model/entities/lecture.dart';
+
+class CalendarService {
+  final DeviceCalendarPlugin _calendarPlugin = DeviceCalendarPlugin();
+
+  Future<List<Calendar>> retrieveWritableCalendars() async {
+    try {
+      var permissionsGranted = await _calendarPlugin.hasPermissions();
+      if (permissionsGranted.isSuccess &&
+          (permissionsGranted.data == null || !permissionsGranted.data!)) {
+        permissionsGranted = await _calendarPlugin.requestPermissions();
+        if (!permissionsGranted.isSuccess ||
+            permissionsGranted.data == null ||
+            !permissionsGranted.data!) {
+          return [];
+        }
+      }
+
+      final calendarsResult = await _calendarPlugin.retrieveCalendars();
+      return calendarsResult.data
+              ?.where((calendar) => calendar.isReadOnly == false)
+              .toList() ??
+          [];
+    } on PlatformException catch (e, st) {
+      debugPrint('RETRIEVE_CALENDARS ERROR: $e\n$st');
+      return [];
+    }
+  }
+
+  Future<void> addLecturesToCalendar(
+    Calendar selectedCalendar,
+    List<Lecture> lectures,
+  ) async {
+    final now = DateTime.now();
+    lectures
+        .where((lecture) => lecture.endTime.isAfter(now))
+        .forEach((lecture) {
+      final event = Event(
+        selectedCalendar.id,
+        title: '${lecture.subject} (${lecture.typeClass})',
+        location: lecture.room,
+        start: tz.TZDateTime.from(lecture.startTime, tz.local),
+        end: tz.TZDateTime.from(lecture.endTime, tz.local),
+      );
+
+      _calendarPlugin.createOrUpdateEvent(event);
+    });
+  }
+}

--- a/packages/uni_app/lib/utils/calendar_service.dart
+++ b/packages/uni_app/lib/utils/calendar_service.dart
@@ -1,9 +1,6 @@
 import 'package:device_calendar/device_calendar.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:timezone/timezone.dart' as tz;
-import 'package:uni/model/entities/exam.dart';
-import 'package:uni/model/entities/lecture.dart';
 
 class CalendarService {
   final DeviceCalendarPlugin _calendarPlugin = DeviceCalendarPlugin();
@@ -30,37 +27,6 @@ class CalendarService {
       debugPrint('RETRIEVE_CALENDARS ERROR: $e\n$st');
       return [];
     }
-  }
-
-  EventDraft createLectureEventDraft(
-    Lecture lecture,
-  ) {
-    return EventDraft(
-      title: '${lecture.subject} (${lecture.typeClass})',
-      location: lecture.room,
-      start: tz.TZDateTime.from(lecture.startTime, tz.local),
-      end: tz.TZDateTime.from(lecture.endTime, tz.local),
-    );
-  }
-
-  Future<void> addLecturesToCalendar(
-    Calendar selectedCalendar,
-    List<Lecture> lectures,
-  ) async {
-    final now = DateTime.now();
-    lectures
-        .where((lecture) => lecture.endTime.isAfter(now))
-        .forEach((lecture) {
-      final event = Event(
-        selectedCalendar.id,
-        title: '${lecture.subject} (${lecture.typeClass})',
-        location: lecture.room,
-        start: tz.TZDateTime.from(lecture.startTime, tz.local),
-        end: tz.TZDateTime.from(lecture.endTime, tz.local),
-      );
-
-      _calendarPlugin.createOrUpdateEvent(event);
-    });
   }
 
   Future<void> addEventsToCalendar(

--- a/packages/uni_app/lib/utils/calendar_service.dart
+++ b/packages/uni_app/lib/utils/calendar_service.dart
@@ -2,6 +2,7 @@ import 'package:device_calendar/device_calendar.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:timezone/timezone.dart' as tz;
+import 'package:uni/model/entities/exam.dart';
 import 'package:uni/model/entities/lecture.dart';
 
 class CalendarService {
@@ -31,6 +32,17 @@ class CalendarService {
     }
   }
 
+  EventDraft createLectureEventDraft(
+    Lecture lecture,
+  ) {
+    return EventDraft(
+      title: '${lecture.subject} (${lecture.typeClass})',
+      location: lecture.room,
+      start: tz.TZDateTime.from(lecture.startTime, tz.local),
+      end: tz.TZDateTime.from(lecture.endTime, tz.local),
+    );
+  }
+
   Future<void> addLecturesToCalendar(
     Calendar selectedCalendar,
     List<Lecture> lectures,
@@ -49,5 +61,67 @@ class CalendarService {
 
       _calendarPlugin.createOrUpdateEvent(event);
     });
+  }
+
+  Future<void> addEventsToCalendar(
+    Calendar selectedCalendar,
+    List<EventDraft> eventDrafts,
+  ) async {
+    for (final draft in eventDrafts) {
+      final event = draft.toEvent(selectedCalendar.id!);
+      try {
+        await _calendarPlugin.createOrUpdateEvent(event);
+      } catch (err, st) {
+        debugPrint('Failed to add event: $err\n$st');
+      }
+    }
+  }
+}
+
+class EventDraft {
+  EventDraft({
+    this.title,
+    this.description,
+    this.start,
+    this.end,
+    this.allDay = false,
+    this.location,
+    this.url,
+    this.attendees,
+    this.recurrenceRule,
+    this.reminders,
+    this.availability = Availability.Busy,
+    this.status,
+  });
+
+  String? title;
+  String? description;
+  TZDateTime? start;
+  TZDateTime? end;
+  bool allDay;
+  String? location;
+  Uri? url;
+  List<Attendee?>? attendees;
+  RecurrenceRule? recurrenceRule;
+  List<Reminder>? reminders;
+  Availability availability;
+  EventStatus? status;
+
+  Event toEvent(String calendarId) {
+    return Event(
+      calendarId,
+      title: title,
+      description: description,
+      start: start,
+      end: end,
+      allDay: allDay,
+      location: location,
+      url: url,
+      attendees: attendees,
+      recurrenceRule: recurrenceRule,
+      reminders: reminders,
+      availability: availability,
+      status: status,
+    );
   }
 }

--- a/packages/uni_app/lib/view/common_widgets/calendar_selection_modal.dart
+++ b/packages/uni_app/lib/view/common_widgets/calendar_selection_modal.dart
@@ -1,0 +1,84 @@
+import 'package:device_calendar/device_calendar.dart';
+import 'package:flutter/material.dart';
+import 'package:uni/utils/calendar_service.dart';
+import 'package:uni_ui/modal/modal.dart';
+
+Future<void> showCalendarModal({
+  required BuildContext context,
+  required List<Calendar> writableCalendars,
+  required CalendarService calendarService,
+  required List<EventDraft> eventDrafts,
+}) async {
+  Calendar? selectedCalendar;
+
+  return showDialog<void>(
+    context: context,
+    builder: (context) {
+      return StatefulBuilder(
+        builder: (context, setModalState) {
+          return ModalDialog(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'Select Calendar',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+              ),
+              const SizedBox(height: 10),
+              if (writableCalendars.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  child: Align(
+                    child: Text(
+                      'No calendars available',
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                  ),
+                )
+              else
+                Flexible(
+                  child: ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: writableCalendars.length,
+                    itemBuilder: (context, index) {
+                      final calendar = writableCalendars[index];
+                      return ListTile(
+                        title: Text(calendar.name ?? 'Unnamed Calendar'),
+                        selected: selectedCalendar?.id == calendar.id,
+                        selectedTileColor:
+                            Theme.of(context).primaryColor.withOpacity(0.2),
+                        tileColor: Theme.of(context).colorScheme.surface,
+                        onTap: () {
+                          setModalState(() {
+                            selectedCalendar = calendar;
+                          });
+                        },
+                      );
+                    },
+                  ),
+                ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: ElevatedButton(
+                  onPressed: selectedCalendar == null
+                      ? null
+                      : () async {
+                          await calendarService.addEventsToCalendar(
+                            selectedCalendar!,
+                            eventDrafts,
+                          );
+                          if (context.mounted) {
+                            Navigator.of(context).pop();
+                          }
+                        },
+                  child: const Text('Add to calendar'),
+                ),
+              ),
+            ],
+          );
+        },
+      );
+    },
+  );
+}

--- a/packages/uni_app/lib/view/exams/widgets/exam_row.dart
+++ b/packages/uni_app/lib/view/exams/widgets/exam_row.dart
@@ -1,8 +1,10 @@
-import 'package:add_2_calendar/add_2_calendar.dart';
 import 'package:flutter/material.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:timezone/timezone.dart' as tz;
 import 'package:uni/controller/local_storage/preferences_controller.dart';
 import 'package:uni/model/entities/exam.dart';
+import 'package:uni/utils/calendar_service.dart';
+import 'package:uni/view/common_widgets/calendar_selection_modal.dart';
 import 'package:uni/view/exams/widgets/exam_time.dart';
 import 'package:uni/view/exams/widgets/exam_title.dart';
 
@@ -104,9 +106,21 @@ class _ExamRowState extends State<ExamRow> {
                         ),
                       IconButton(
                         icon: Icon(MdiIcons.calendarPlus, size: 30),
-                        onPressed: () => Add2Calendar.addEvent2Cal(
-                          createExamEvent(),
-                        ),
+                        onPressed: () async {
+                          final calendarService = CalendarService();
+                          final writableCalendars =
+                              await calendarService.retrieveWritableCalendars();
+
+                          final examEventDraft =
+                              createExamEventDraft(widget.exam);
+
+                          await showCalendarModal(
+                            context: context,
+                            writableCalendars: writableCalendars,
+                            calendarService: calendarService,
+                            eventDrafts: [examEventDraft],
+                          );
+                        },
                       ),
                     ],
                   ),
@@ -143,12 +157,14 @@ class _ExamRowState extends State<ExamRow> {
         .toList();
   }
 
-  Event createExamEvent() {
-    return Event(
+  EventDraft createExamEventDraft(
+    Exam exam,
+  ) {
+    return EventDraft(
       title: '${widget.exam.examType} ${widget.exam.subjectAcronym}',
       location: widget.exam.rooms.toString(),
-      startDate: widget.exam.start,
-      endDate: widget.exam.finish,
+      start: tz.TZDateTime.from(widget.exam.start, tz.local),
+      end: tz.TZDateTime.from(widget.exam.finish, tz.local),
     );
   }
 }

--- a/packages/uni_app/lib/view/schedule/schedule.dart
+++ b/packages/uni_app/lib/view/schedule/schedule.dart
@@ -135,7 +135,15 @@ class SchedulePageViewState extends State<SchedulePageView>
                     setState(() {
                       _calendars = calendars;
                     });
-                    await showCalendarModal(calendarService);
+                    final lectureEventDrafts = widget.lectures
+                        .where((lecture) =>
+                            lecture.endTime.isAfter(DateTime.now()))
+                        .map(calendarService.createLectureEventDraft)
+                        .toList();
+                    await showCalendarModal(
+                      calendarService,
+                      lectureEventDrafts,
+                    );
                   }
                 },
                 child: const Text('Save lectures'),
@@ -244,7 +252,10 @@ class SchedulePageViewState extends State<SchedulePageView>
     );
   }
 
-  Future<void> showCalendarModal(CalendarService calendarService) async {
+  Future<void> showCalendarModal(
+    CalendarService calendarService,
+    List<EventDraft> eventDrafts,
+  ) async {
     return showDialog<void>(
       context: context,
       builder: (context) {
@@ -299,9 +310,9 @@ class SchedulePageViewState extends State<SchedulePageView>
                         ? null
                         : () async {
                             if (_writableCalendars.isNotEmpty) {
-                              await calendarService.addLecturesToCalendar(
+                              await calendarService.addEventsToCalendar(
                                 _selectedCalendar!,
-                                widget.lectures,
+                                eventDrafts,
                               );
                             }
                             if (mounted) {

--- a/packages/uni_app/pubspec.yaml
+++ b/packages/uni_app/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   crypto: ^3.0.1
   cupertino_icons: ^1.0.2
   currency_text_input_formatter: ^2.1.5
+  device_calendar: ^4.3.3
   diacritic: ^0.1.5
   email_validator: ^2.0.1
   expandable: ^5.0.1

--- a/packages/uni_app/pubspec.yaml
+++ b/packages/uni_app/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   sqflite: ^2.0.3
   synchronized: ^3.0.0
   timelines: ^0.1.0
+  timezone: ^0.9.4
   ua_client_hints: ^1.3.1
   uni_ui:
     path: ../uni_ui


### PR DESCRIPTION
Closes #1382 

This implements the feature of saving all of the semester's lectures directly to the device's calendar (Google calendar, Apple calendar, etc). It also replaces the previous logic to save the exams.

https://github.com/user-attachments/assets/ddc81c5d-c1ae-46bc-afd1-ee3d8fefdbdc

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
