### PR TITLE
Uniformize all timelines padding and width

### DIFF
--- a/packages/uni_app/lib/view/academic_path/exam_page.dart
+++ b/packages/uni_app/lib/view/academic_path/exam_page.dart
@@ -43,17 +43,32 @@ class _ExamsPageState extends State<ExamsPage> {
           final allMonths = List.generate(12, (index) => index + 1);
           final tabs = allMonths.map((month) {
             final date = DateTime(DateTime.now().year, month);
-            return Column(
-              children: [
-                Text(
-                  date.shortMonth(
-                    Provider.of<LocaleNotifier>(context).getLocale(),
+            return SizedBox(
+              width: 30,
+              height: 34,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Expanded(
+                    child: Text(
+                      date.shortMonth(
+                        Provider.of<LocaleNotifier>(context).getLocale(),
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
+                    ),
                   ),
-                ),
-                Text(
-                  '${date.month}',
-                ),
-              ],
+                  Expanded(
+                    child: Text(
+                      '${date.month}',
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
+                    ),
+                  ),
+                ],
+              ),
             );
           }).toList();
           final content = allMonths.map((month) {

--- a/packages/uni_app/lib/view/academic_path/exam_page.dart
+++ b/packages/uni_app/lib/view/academic_path/exam_page.dart
@@ -79,7 +79,7 @@ class _ExamsPageState extends State<ExamsPage> {
               children: [
                 if (exams.isNotEmpty)
                   Padding(
-                    padding: const EdgeInsets.all(16),
+                    padding: const EdgeInsets.fromLTRB(24, 0, 24, 8),
                     child: Text(
                       DateTime(DateTime.now().year, month)
                           .fullMonth(
@@ -96,7 +96,7 @@ class _ExamsPageState extends State<ExamsPage> {
                   itemBuilder: (context, index) {
                     final exam = exams[index];
                     return Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 4),
+                      padding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
                       child: TimelineItem(
                         title: exam.start.day.toString(),
                         subtitle: exam.start
@@ -132,20 +132,17 @@ class _ExamsPageState extends State<ExamsPage> {
               ],
             );
           }).toList();
-          return Padding(
-            padding: const EdgeInsets.all(8),
-            child: Timeline(
-              tabs: tabs,
-              content: content,
-              initialTab: allMonths.indexWhere((month) {
-                final monthKey = '${DateTime.now().year}-$month';
-                return examsByMonth.containsKey(monthKey);
-              }),
-              tabEnabled: allMonths.map((month) {
-                final monthKey = '${DateTime.now().year}-$month';
-                return examsByMonth.containsKey(monthKey);
-              }).toList(),
-            ),
+          return Timeline(
+            tabs: tabs,
+            content: content,
+            initialTab: allMonths.indexWhere((month) {
+              final monthKey = '${DateTime.now().year}-$month';
+              return examsByMonth.containsKey(monthKey);
+            }),
+            tabEnabled: allMonths.map((month) {
+              final monthKey = '${DateTime.now().year}-$month';
+              return examsByMonth.containsKey(monthKey);
+            }).toList(),
           );
         },
         hasContent: (exams) => exams.isNotEmpty,

--- a/packages/uni_app/lib/view/restaurant/widgets/day_of_week_tab.dart
+++ b/packages/uni_app/lib/view/restaurant/widgets/day_of_week_tab.dart
@@ -39,12 +39,18 @@ class DayOfWeekTab extends StatelessWidget {
                   style: isSelected
                       ? Theme.of(context).textTheme.bodySmall
                       : Theme.of(context).textTheme.bodyLarge,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                  maxLines: 1,
                 ),
                 Text(
                   day,
                   style: isSelected
                       ? Theme.of(context).textTheme.bodySmall
                       : Theme.of(context).textTheme.bodyLarge,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                  maxLines: 1,
                 ),
               ],
             ),

--- a/packages/uni_app/lib/view/restaurant/widgets/days_of_week_tab_bar.dart
+++ b/packages/uni_app/lib/view/restaurant/widgets/days_of_week_tab_bar.dart
@@ -19,7 +19,7 @@ class DaysOfWeekTabBar extends StatelessWidget {
       isScrollable: true,
       padding: EdgeInsets.zero,
       indicator: const BoxDecoration(),
-      labelPadding: const EdgeInsets.symmetric(horizontal: 3),
+      labelPadding: const EdgeInsets.symmetric(horizontal: 5),
       tabAlignment: TabAlignment.center,
       tabs: createTabs(context),
       dividerHeight: 0,


### PR DESCRIPTION
Closes #1492 

I think it is done, given the differences in how the pages were constructed the exact values of paddings and sizes are different, but visually I think they are almost indistinguishable now. 

<img src="https://github.com/user-attachments/assets/c758b1fb-ee6d-4556-a3a6-60c7d0e5181f" width="250">
<img src="https://github.com/user-attachments/assets/c2f74f81-7d28-4654-b5b1-f54e696bf580" width="250">
<img src="https://github.com/user-attachments/assets/013d9c2d-de57-4f58-85db-91d2b535118b" width="250">

In another note, shouldn't the restaurant page's week be starting from Sunday?

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [x] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [x] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code
