### PR TITLE
Fix: restaurant's timeline background

### DIFF
--- a/packages/uni_app/lib/view/restaurant/widgets/days_of_week_tab_bar.dart
+++ b/packages/uni_app/lib/view/restaurant/widgets/days_of_week_tab_bar.dart
@@ -23,6 +23,7 @@ class DaysOfWeekTabBar extends StatelessWidget {
       tabAlignment: TabAlignment.center,
       tabs: createTabs(context),
       dividerHeight: 0,
+      overlayColor: WidgetStateProperty.all(Colors.transparent),
     );
   }
 


### PR DESCRIPTION
Closes #1488 
Added an overlayColor to the days_of_week_bar_tab widget to correct the restaurant's timeline background.

## Screenshots

### Before
https://github.com/user-attachments/assets/1b639af5-cf5f-4d9a-9058-024a23e2a835

### After
https://github.com/user-attachments/assets/d266c7e4-2167-4666-9ec2-e1f39c9f8950

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
