### PR TITLE
Fix: course page top blank padding

### DIFF
--- a/packages/uni_app/lib/view/academic_path/courses_page.dart
+++ b/packages/uni_app/lib/view/academic_path/courses_page.dart
@@ -72,7 +72,7 @@ class CoursesPageState extends State<CoursesPage> {
         final course = courses[courseUnitIndex];
 
         return Padding(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.only(left: 16, right: 16, bottom: 16),
           child: ListView(
             children: [
               Center(

--- a/packages/uni_app/lib/view/academic_path/courses_page.dart
+++ b/packages/uni_app/lib/view/academic_path/courses_page.dart
@@ -32,7 +32,7 @@ class CoursesPageState extends State<CoursesPage> {
   double _getTotalCredits(Profile profile, Course course) {
     return profile.courseUnits
         .where((courseUnit) => courseUnit.festId == course.festId)
-        .map((courseUnit) => (courseUnit.ects ?? 0) as double)
+        .map((courseUnit) => (courseUnit.ects ?? 0).toDouble())
         .fold(0, (a, b) => a + b);
   }
 


### PR DESCRIPTION
Closes #1491 
Applied padding only on left, right and bottom.

## Screenshots

Before            |  After
:----------------:|:-------------------------:
![](https://github.com/user-attachments/assets/f9cced61-ab2a-4fca-bc6c-1b9f5273879d)  |  ![](https://github.com/user-attachments/assets/7458588c-93ca-4ae8-9f12-46929cdfe1ea)

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
