### PR TITLE
Fix course card color and width

### DIFF
--- a/packages/uni_ui/lib/courses/course_card.dart
+++ b/packages/uni_ui/lib/courses/course_card.dart
@@ -15,14 +15,17 @@ class CourseCard extends StatelessWidget {
   final bool selected;
   final void Function() onTap;
 
+  Color get grayColor => Colors.grey.shade100;
+  Color get onGrayColor => Colors.grey.shade600;
+
   @override
   Widget build(BuildContext context) {
     return GenericCard(
       key: key,
       onClick: onTap,
       color: selected
-          ? Theme.of(context).colorScheme.surfaceDim
-          : Theme.of(context).colorScheme.surfaceContainerLow,
+          ? Theme.of(context).colorScheme.surfaceContainerLow
+          : grayColor,
       tooltip: '',
       child: IntrinsicWidth(
         child: Padding(
@@ -33,19 +36,25 @@ class CourseCard extends StatelessWidget {
               PhosphorIcon(
                 _getIconData(courseInfo.abbreviation, selected),
                 size: 32,
+                color: selected
+                    ? Theme.of(context).colorScheme.primary
+                    : onGrayColor,
               ),
               Text(
                 courseInfo.abbreviation,
-                style: Theme.of(context)
-                    .textTheme
-                    .titleLarge
-                    ?.apply(color: Theme.of(context).colorScheme.primary),
+                style: Theme.of(context).textTheme.titleLarge?.apply(
+                    color: selected
+                        ? Theme.of(context).colorScheme.primary
+                        : onGrayColor),
               ),
               Text(
                 courseInfo.conclusionYear == null
                     ? 'now'
                     : '${courseInfo.enrollmentYear}/${courseInfo.conclusionYear}',
-                style: Theme.of(context).textTheme.bodySmall,
+                style: Theme.of(context).textTheme.bodySmall?.apply(
+                    color: selected
+                        ? Theme.of(context).colorScheme.primary
+                        : onGrayColor),
               ),
             ],
           ),

--- a/packages/uni_ui/lib/courses/course_card.dart
+++ b/packages/uni_ui/lib/courses/course_card.dart
@@ -24,27 +24,31 @@ class CourseCard extends StatelessWidget {
           ? Theme.of(context).colorScheme.surfaceDim
           : Theme.of(context).colorScheme.surfaceContainerLow,
       tooltip: '',
-      child: SizedBox(
-        width: 65,
-        child: Column(
-          children: [
-            PhosphorIcon(
-              _getIconData(courseInfo.abbreviation, selected),
-              size: 32,
-            ),
-            Text(
-              courseInfo.abbreviation,
-              style: Theme.of(context)
-                  .textTheme
-                  .titleLarge
-                  ?.apply(color: Theme.of(context).colorScheme.primary),
-            ),
-            Text(
+      child: IntrinsicWidth(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 5.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              PhosphorIcon(
+                _getIconData(courseInfo.abbreviation, selected),
+                size: 32,
+              ),
+              Text(
+                courseInfo.abbreviation,
+                style: Theme.of(context)
+                    .textTheme
+                    .titleLarge
+                    ?.apply(color: Theme.of(context).colorScheme.primary),
+              ),
+              Text(
                 courseInfo.conclusionYear == null
                     ? 'now'
                     : '${courseInfo.enrollmentYear}/${courseInfo.conclusionYear}',
-                style: Theme.of(context).textTheme.bodySmall),
-          ],
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/packages/uni_ui/lib/courses/course_card.dart
+++ b/packages/uni_ui/lib/courses/course_card.dart
@@ -3,6 +3,7 @@ import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:uni_ui/cards/generic_card.dart';
 import 'package:uni_ui/courses/course_info.dart';
 import 'package:uni_ui/icons.dart';
+import 'package:uni_ui/theme.dart';
 
 class CourseCard extends StatelessWidget {
   const CourseCard({
@@ -16,10 +17,6 @@ class CourseCard extends StatelessWidget {
   final bool selected;
   final void Function() onTap;
 
-  Color get grayColor => Colors.grey.shade100;
-
-  Color get onGrayColor => Colors.grey.shade600;
-
   @override
   Widget build(BuildContext context) {
     return GenericCard(
@@ -27,7 +24,7 @@ class CourseCard extends StatelessWidget {
       onClick: onTap,
       color: selected
           ? Theme.of(context).colorScheme.surfaceContainerLow
-          : grayColor,
+          : grayLight,
       tooltip: '',
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 5.0),
@@ -41,14 +38,14 @@ class CourseCard extends StatelessWidget {
                 size: 32,
                 color: selected
                     ? Theme.of(context).colorScheme.primary
-                    : onGrayColor,
+                    : grayMiddle,
               ),
               Text(
                 courseInfo.abbreviation,
                 style: Theme.of(context).textTheme.titleLarge?.apply(
                     color: selected
                         ? Theme.of(context).colorScheme.primary
-                        : onGrayColor),
+                        : grayMiddle),
               ),
               Text(
                 courseInfo.conclusionYear == null
@@ -57,7 +54,7 @@ class CourseCard extends StatelessWidget {
                 style: Theme.of(context).textTheme.bodySmall?.apply(
                     color: selected
                         ? Theme.of(context).colorScheme.primary
-                        : onGrayColor),
+                        : grayMiddle),
               ),
             ],
           ),

--- a/packages/uni_ui/lib/courses/course_card.dart
+++ b/packages/uni_ui/lib/courses/course_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:uni_ui/cards/generic_card.dart';
 import 'package:uni_ui/courses/course_info.dart';
+import 'package:uni_ui/icons.dart';
 
 class CourseCard extends StatelessWidget {
   const CourseCard({
@@ -33,7 +34,7 @@ class CourseCard extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              PhosphorIcon(
+              UniIcon(
                 _getIconData(courseInfo.abbreviation, selected),
                 size: 32,
                 color: selected

--- a/packages/uni_ui/lib/courses/course_card.dart
+++ b/packages/uni_ui/lib/courses/course_card.dart
@@ -17,6 +17,7 @@ class CourseCard extends StatelessWidget {
   final void Function() onTap;
 
   Color get grayColor => Colors.grey.shade100;
+
   Color get onGrayColor => Colors.grey.shade600;
 
   @override
@@ -28,9 +29,10 @@ class CourseCard extends StatelessWidget {
           ? Theme.of(context).colorScheme.surfaceContainerLow
           : grayColor,
       tooltip: '',
-      child: IntrinsicWidth(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 5.0),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 5.0),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minWidth: 55),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [

--- a/packages/uni_ui/lib/theme.dart
+++ b/packages/uni_ui/lib/theme.dart
@@ -5,6 +5,7 @@ const Color primaryVibrant = Color.fromARGB(255, 102, 9, 16);
 const Color secondary = Color.fromARGB(255, 255, 245, 243);
 const Color grayText = Color.fromARGB(255, 48, 48, 48);
 const Color grayMiddle = Color.fromARGB(255, 127, 127, 127);
+const Color grayLight = Color.fromARGB(255, 245, 245, 245);
 const Color background = Color.fromARGB(255, 255, 255, 255);
 const Color details = Color.fromARGB(235, 177, 77, 84);
 const Color divider = Color.fromARGB(255, 229, 229, 229);


### PR DESCRIPTION
Closes #1490 
before:
![image](https://github.com/user-attachments/assets/b3093f5b-6cb5-41e7-bc97-3549ad598dfd)

after:
![image](https://github.com/user-attachments/assets/c709cc9c-436c-4cd3-8890-addf7f0fb325)

to-dos
- [x] make width expandable
- [x] change color to resemble Figma (unselected should be gray)

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
