### PR TITLE
Fixed clickable area that was only on the text in the GenericCard

### DIFF
--- a/packages/uni_ui/lib/cards/generic_card.dart
+++ b/packages/uni_ui/lib/cards/generic_card.dart
@@ -46,17 +46,18 @@ class GenericCard extends StatelessWidget {
             ),
           ],
         ),
-        child: GenericSquircle(child: Container(
-            decoration: BoxDecoration(
-              color: color ??
-                  cardTheme.color ??
-                  theme.colorScheme.surfaceContainer,
-              gradient: gradient,
-            ),
-            child: Padding(
-              padding: padding ?? const EdgeInsets.all(10),
-              child: GestureDetector(
-                onTap: onClick,
+        child: GestureDetector(
+          onTap: onClick,
+          child: GenericSquircle(
+            child: Container(
+              decoration: BoxDecoration(
+                color: color ??
+                    cardTheme.color ??
+                    theme.colorScheme.surfaceContainer,
+                gradient: gradient,
+              ),
+              child: Padding(
+                padding: padding ?? const EdgeInsets.all(10),
                 child: child,
               ),
             ),


### PR DESCRIPTION
Closes #1489 

Fixed the bug, reorder the gesture detector in the GenericCard widget.
