### PR TITLE
Fix for #1494 .

### DIFF
--- a/packages/uni_app/lib/view/academic_path/academic_path.dart
+++ b/packages/uni_app/lib/view/academic_path/academic_path.dart
@@ -43,12 +43,24 @@ class AcademicPathPageViewState extends GeneralPageViewState
       controller: tabController,
       dividerHeight: 1,
       tabs: [
-        TabIcon(icon: UniIcons.course, text: S.of(context).courses),
-        TabIcon(
-          icon: UniIcons.lecture,
-          text: S.of(context).schedule,
-        ),
-        TabIcon(icon: UniIcons.exam, text: S.of(context).exams),
+        Tab(child:
+        Row(children:
+        [const Icon(UniIcons.courses),
+          Expanded(child: Text(S.of(context).courses, overflow: TextOverflow.ellipsis),),],),),
+        Tab(child:
+        Row(children:
+        [const Icon(UniIcons.lecture),
+          Expanded(child: Text(S.of(context).lectures, overflow: TextOverflow.ellipsis),),],),),
+        Tab(child:
+        Row(children:
+        [const Icon(UniIcons.exam),
+          Expanded(child: Text(S.of(context).exams, overflow: TextOverflow.ellipsis),),],),),
+        /* OLD CODE:
+              TabIcon(icon: UniIcons.course, text: Text(S.of(context).courses, overflow: TextOverflow.ellipsis),), TabIcon(
+              icon: UniIcons.lecture,
+              text: S.of(context).schedule,
+            ),
+            TabIcon(icon: UniIcons.exam, text: S.of(context).exams),*/
       ],
     );
   }


### PR DESCRIPTION
Closes #1494  
Changed the tab structure to allow text overflow ellipsis. Left old code as comment for comparison.
![imagem](https://github.com/user-attachments/assets/132a40a0-6b8c-4745-b8f8-3125f3a368e9)

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
