### PR TITLE
fix: schedule page double refresh indicator

### DIFF
--- a/packages/uni_app/lib/view/academic_path/schedule_page.dart
+++ b/packages/uni_app/lib/view/academic_path/schedule_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:uni/model/entities/lecture.dart';
 import 'package:uni/model/providers/lazy/lecture_provider.dart';
 import 'package:uni/view/academic_path/widgets/no_classes_widget.dart';
@@ -15,51 +14,33 @@ class SchedulePage extends StatelessWidget {
   Widget build(BuildContext context) {
     const bottomNavbarHeight = 120.0;
 
-    return MediaQuery.removePadding(
-      context: context,
-      removeBottom: true,
-      child: RefreshIndicator(
-        onRefresh: () async {
-          await context.read<LectureProvider>().forceRefresh(context);
-        },
-        child: LazyConsumer<LectureProvider, List<Lecture>>(
-          builder: (context, lectures) {
-            final startOfWeek = _getStartOfWeek(now, lectures);
+    return LazyConsumer<LectureProvider, List<Lecture>>(
+      builder: (context, lectures) {
+        final startOfWeek = _getStartOfWeek(now, lectures);
 
-            return SchedulePageView(
-              lectures,
-              startOfWeek: startOfWeek,
-              now: now,
-            );
-          },
-          hasContent: (lectures) => lectures.isNotEmpty,
-          onNullContent: LayoutBuilder(
-            builder: (context, constraints) => SingleChildScrollView(
-              physics:
-                  const AlwaysScrollableScrollPhysics(), // Ensures refresh works
-              child: Container(
-                height: constraints.maxHeight,
-                padding: const EdgeInsets.only(bottom: bottomNavbarHeight),
-                child: const Center(
-                  child: NoClassesWidget(),
-                ),
-              ),
+        return SchedulePageView(
+          lectures,
+          startOfWeek: startOfWeek,
+          now: now,
+        );
+      },
+      hasContent: (lectures) => lectures.isNotEmpty,
+      onNullContent: LayoutBuilder(
+        builder: (context, constraints) => SingleChildScrollView(
+          physics:
+              const AlwaysScrollableScrollPhysics(), // Ensures refresh works
+          child: Container(
+            height: constraints.maxHeight,
+            padding: const EdgeInsets.only(bottom: bottomNavbarHeight),
+            child: const Center(
+              child: NoClassesWidget(),
             ),
           ),
-          mapper: (lectures) {
-            final startOfWeek = _getStartOfWeek(now, lectures);
-            final endOfNextWeek = startOfWeek.add(const Duration(days: 14));
-
-            return lectures
-                .where(
-                  (lecture) =>
-                      lecture.startTime.isAfter(startOfWeek) &&
-                      lecture.startTime.isBefore(endOfNextWeek),
-                )
-                .toList();
-          },
         ),
       ),
+      mapper: (lectures) {
+        return [];
+      },
     );
   }
 


### PR DESCRIPTION
Closes #1479
Removes the double refresh indicator at the schedule page.

## Screenshot

https://github.com/user-attachments/assets/ced710bb-08a7-4892-9427-7524add24620

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code