### PR TITLE
fix: exam card height

### DIFF
--- a/packages/uni_ui/lib/cards/exam_card.dart
+++ b/packages/uni_ui/lib/cards/exam_card.dart
@@ -47,6 +47,7 @@ class ExamCard extends StatelessWidget {
           children: [
             Expanded(
               child: Column(
+                mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Row(


### PR DESCRIPTION
Closes #1507
removed small padding on bottom of exam card 

before  |  after
:--:|:--:
![IMG_1648](https://github.com/user-attachments/assets/61d108b3-bf59-4470-8e11-5c6cb05d14a3) | ![IMG_1649](https://github.com/user-attachments/assets/828c0ce4-98b1-4516-a970-4b6b83099539)


# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
