### PR TITLE
Redesign/profile

### DIFF
--- a/packages/uni_app/lib/view/profile/widgets/profile_overview.dart
+++ b/packages/uni_app/lib/view/profile/widgets/profile_overview.dart
@@ -16,6 +16,8 @@ class ProfileOverview extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final session = context.read<SessionProvider>().state!;
+    final name = profile.name.split(' ');
+
     return FutureBuilder(
       future: ProfileProvider.fetchOrGetCachedProfilePicture(
         session,
@@ -26,7 +28,7 @@ class ProfileOverview extends StatelessWidget {
           const ProfileImage(radius: 75),
           const Padding(padding: EdgeInsets.all(8)),
           Text(
-            profile.name,
+            '${name.first} ${name.length > 1 ? name.last : ''}',
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.headlineLarge,
           ),
@@ -45,6 +47,7 @@ class ProfileOverview extends StatelessWidget {
                   style: Theme.of(context).textTheme.titleSmall,
                 ),
                 backgroundColor: Theme.of(context).colorScheme.primary,
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
               );
             }).toList(),
           ),

--- a/packages/uni_app/lib/view/profile/widgets/settings.dart
+++ b/packages/uni_app/lib/view/profile/widgets/settings.dart
@@ -67,7 +67,10 @@ class Settings extends StatelessWidget {
               icon: UniIcons.thumbsUp,
               title: S.of(context).leave_feedback,
               subtitle: S.of(context).feedback_description,
-              trailing: const Icon(Icons.arrow_forward_ios),
+              trailing: UniIcon(
+                UniIcons.caretRight,
+                color: Theme.of(context).colorScheme.primary,
+              ),
               onTap: () {
                 Navigator.push(
                   context,
@@ -84,7 +87,10 @@ class Settings extends StatelessWidget {
             child: ProfileListTile(
               icon: UniIcons.gavel,
               title: S.of(context).terms,
-              trailing: const Icon(Icons.arrow_forward_ios),
+              trailing: UniIcon(
+                UniIcons.caretRight,
+                color: Theme.of(context).colorScheme.primary,
+              ),
               onTap: () {
                 Navigator.push(
                   context,
@@ -101,7 +107,10 @@ class Settings extends StatelessWidget {
             child: ProfileListTile(
               icon: UniIcons.signOut,
               title: S.of(context).logout,
-              trailing: const Icon(Icons.arrow_forward_ios),
+              trailing: UniIcon(
+                UniIcons.caretRight,
+                color: Theme.of(context).colorScheme.primary,
+              ),
               onTap: NetworkRouter.authenticationController?.close,
             ),
           ),


### PR DESCRIPTION
Closes #1524 


Changes:
- Add padding to badges;
- Show only first and last names;
- Use `PhosphorIcon`s;

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/56ea85e4-9a21-4ad2-90b6-5482dc657cff" width="300"> | <img src="https://github.com/user-attachments/assets/cd4d8c69-4dd5-4c84-9196-a78e0d0ad32c" width="300"> |
| <img src="https://github.com/user-attachments/assets/ee5ae9fb-3aef-4275-a2ae-e427b5e849dd" width="300"> | <img src="https://github.com/user-attachments/assets/0a57ed01-38a8-485f-8f96-8770530db3e2" width="300"> |
