### PR TITLE
Fix courses page for courses with no ECTS

### DIFF
--- a/packages/uni_app/lib/generated/intl/messages_en.dart
+++ b/packages/uni_app/lib/generated/intl/messages_en.dart
@@ -281,6 +281,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "no_trips": MessageLookupByLibrary.simpleMessage(
             "No trips found at the moment"),
         "notifications": MessageLookupByLibrary.simpleMessage("Notifications"),
+        "now": MessageLookupByLibrary.simpleMessage("Now"),
         "occurrence_type":
             MessageLookupByLibrary.simpleMessage("Type of occurrence"),
         "of_month": MessageLookupByLibrary.simpleMessage("of"),

--- a/packages/uni_app/lib/generated/intl/messages_pt_PT.dart
+++ b/packages/uni_app/lib/generated/intl/messages_pt_PT.dart
@@ -280,6 +280,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "no_trips": MessageLookupByLibrary.simpleMessage(
             "Não há viagens planeadas de momento"),
         "notifications": MessageLookupByLibrary.simpleMessage("Notificações"),
+        "now": MessageLookupByLibrary.simpleMessage("Agora"),
         "occurrence_type":
             MessageLookupByLibrary.simpleMessage("Tipo de ocorrência"),
         "of_month": MessageLookupByLibrary.simpleMessage("de"),

--- a/packages/uni_app/lib/generated/l10n.dart
+++ b/packages/uni_app/lib/generated/l10n.dart
@@ -1983,6 +1983,16 @@ class S {
       args: [],
     );
   }
+
+  /// `Now`
+  String get now {
+    return Intl.message(
+      'Now',
+      name: 'now',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/packages/uni_app/lib/l10n/intl_en.arb
+++ b/packages/uni_app/lib/l10n/intl_en.arb
@@ -389,5 +389,7 @@
   "no_courses": "No courses we're found",
   "@no_courses": {},
   "no_courses_description": "Try to refresh the page",
-  "@no_courses_description": {}
+  "@no_courses_description": {},
+  "now": "Now",
+  "@now": {}
 }

--- a/packages/uni_app/lib/l10n/intl_pt_PT.arb
+++ b/packages/uni_app/lib/l10n/intl_pt_PT.arb
@@ -388,5 +388,7 @@
   "no_courses": "Não foram encontrados cursos",
   "@no_courses": {},
   "no_courses_description": "Tenta refrescar a página",
-  "@no_courses_description": {}
+  "@no_courses_description": {},
+  "now": "Agora",
+  "@now": {}
 }

--- a/packages/uni_app/lib/view/academic_path/courses_page.dart
+++ b/packages/uni_app/lib/view/academic_path/courses_page.dart
@@ -80,7 +80,7 @@ class CoursesPageState extends State<CoursesPage> {
                   courseInfos: courses.map((course) {
                     return CourseInfo(
                       abbreviation: _getCourseAbbreviation(course),
-                      enrollmentYear: course.firstEnrollment!,
+                      enrollmentYear: course.firstEnrollment,
                       conclusionYear: _getConclusionYear(course),
                     );
                   }).toList(),
@@ -98,7 +98,7 @@ class CoursesPageState extends State<CoursesPage> {
               Padding(
                 padding: const EdgeInsets.only(top: 40, bottom: 8),
                 child: AverageBar(
-                  average: (course.currentAverage ?? double.nan).toDouble(),
+                  average: (course.currentAverage ?? 0).toDouble(),
                   completedCredits: (course.finishedEcts ?? 0).toDouble(),
                   totalCredits: _getTotalCredits(profile, course),
                   statusText: course.state ?? '',

--- a/packages/uni_app/lib/view/academic_path/courses_page.dart
+++ b/packages/uni_app/lib/view/academic_path/courses_page.dart
@@ -86,6 +86,7 @@ class CoursesPageState extends State<CoursesPage> {
                   }).toList(),
                   onSelected: _onCourseUnitSelected,
                   selected: courseUnitIndex,
+                  nowText: S.of(context).now,
                 ),
               ),
               Padding(

--- a/packages/uni_app/lib/view/academic_path/courses_page.dart
+++ b/packages/uni_app/lib/view/academic_path/courses_page.dart
@@ -36,6 +36,24 @@ class CoursesPageState extends State<CoursesPage> {
         .fold(0, (a, b) => a + b);
   }
 
+  int? _getEnrollmentYear(Course course) {
+    if (course.state == null) {
+      return null;
+    }
+
+    if (course.state != 'A Frequentar' &&
+        !(course.state?.startsWith('Concluído') ?? false)) {
+      return null;
+    }
+
+    if (course.firstEnrollment == null) {
+      final now = DateTime.now();
+      return DateTime(now.year, now.month - 8, now.day).year;
+    }
+
+    return course.firstEnrollment!;
+  }
+
   int? _getConclusionYear(Course course) {
     if (course.state == null || course.state == 'A Frequentar') {
       return null;
@@ -80,7 +98,7 @@ class CoursesPageState extends State<CoursesPage> {
                   courseInfos: courses.map((course) {
                     return CourseInfo(
                       abbreviation: _getCourseAbbreviation(course),
-                      enrollmentYear: course.firstEnrollment,
+                      enrollmentYear: _getEnrollmentYear(course),
                       conclusionYear: _getConclusionYear(course),
                     );
                   }).toList(),

--- a/packages/uni_app/lib/view/academic_path/widgets/course_units_view.dart
+++ b/packages/uni_app/lib/view/academic_path/widgets/course_units_view.dart
@@ -107,9 +107,8 @@ class _CourseUnitsViewState extends State<CourseUnitsView> {
               shrinkWrap: true,
               childAspectRatio: isGrid
                   ? (width - 40) / (width * 2) * 5
-                  : (width - 32) /
-                      width *
-                      5, // Calculate aspect ratio, to avoid inconsistencies between grid and list view
+                  : (width - 32) / width * 5,
+              // Calculate aspect ratio, to avoid inconsistencies between grid and list view
               mainAxisSpacing: 8,
               crossAxisSpacing: 8,
               children: courseGradeCards,

--- a/packages/uni_app/lib/view/academic_path/widgets/course_units_view.dart
+++ b/packages/uni_app/lib/view/academic_path/widgets/course_units_view.dart
@@ -134,7 +134,7 @@ class _CourseUnitsViewState extends State<CourseUnitsView> {
   CourseGradeCard _toCourseGradeCard(CourseUnit unit, BuildContext context) {
     return CourseGradeCard(
       courseName: unit.name,
-      ects: unit.ects! as double,
+      ects: (unit.ects ?? 0).toDouble(),
       grade: unit.grade != null ? double.tryParse(unit.grade!)?.round() : null,
       tooltip: unit.name,
       onTap: () => _toCourseGradeCardOnTap(unit, context),

--- a/packages/uni_ui/lib/courses/average_bar.dart
+++ b/packages/uni_ui/lib/courses/average_bar.dart
@@ -27,44 +27,53 @@ class AverageBar extends StatelessWidget {
     return LayoutBuilder(builder: (context, constraints) {
       return Row(children: [
         GenericSquircle(
-            child: Container(
-                decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.secondary,
-                    borderRadius: BorderRadius.all(Radius.circular(5))),
-                width: constraints.maxWidth * 0.25,
-                height: 50,
-                child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(averageText),
-                      Text(average.toString(),
-                          style: TextStyle(
-                              fontWeight: FontWeight.bold, fontSize: 18))
-                    ]))),
-        SizedBox(width: constraints.maxWidth * 0.05),
-        Container(
-            width: constraints.maxWidth * 0.70,
+          child: Container(
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.secondary,
+              borderRadius: BorderRadius.all(Radius.circular(5)),
+            ),
+            width: constraints.maxWidth * 0.25,
             height: 50,
             child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Tooltip(
-                          message: "European Credit System",
-                          child: Text("ECTS"),
-                        ),
-                        Text(
-                            '${_displayNumber(completedCredits)}/${_displayNumber(totalCredits)}'),
-                      ]),
-                  LinearProgressIndicator(
-                      minHeight: 8,
-                      value: completedCredits / totalCredits,
-                      borderRadius: BorderRadius.all(Radius.circular(5))),
-                  Text(statusText)
-                ]))
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(averageText),
+                Text(
+                  average.toString(),
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 18,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        SizedBox(width: constraints.maxWidth * 0.05),
+        Container(
+          width: constraints.maxWidth * 0.70,
+          height: 50,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+                Tooltip(
+                  message: "European Credit System",
+                  child: Text("ECTS"),
+                ),
+                Text(
+                    '${_displayNumber(completedCredits)}/${_displayNumber(totalCredits)}'),
+              ]),
+              LinearProgressIndicator(
+                  minHeight: 8,
+                  value:
+                      totalCredits != 0 ? completedCredits / totalCredits : 1,
+                  borderRadius: BorderRadius.all(Radius.circular(5))),
+              Text(statusText)
+            ],
+          ),
+        )
       ]);
     });
   }

--- a/packages/uni_ui/lib/courses/average_bar.dart
+++ b/packages/uni_ui/lib/courses/average_bar.dart
@@ -39,7 +39,7 @@ class AverageBar extends StatelessWidget {
               children: [
                 Text(averageText),
                 Text(
-                  average.toString(),
+                  average != 0 ? average.toString() : '---',
                   style: TextStyle(
                     fontWeight: FontWeight.bold,
                     fontSize: 18,

--- a/packages/uni_ui/lib/courses/course_card.dart
+++ b/packages/uni_ui/lib/courses/course_card.dart
@@ -17,6 +17,18 @@ class CourseCard extends StatelessWidget {
   final bool selected;
   final void Function() onTap;
 
+  String _getYearText() {
+    if (courseInfo.enrollmentYear == null) {
+      return '';
+    }
+
+    if (courseInfo.conclusionYear == null) {
+      return 'now';
+    }
+
+    return '${courseInfo.enrollmentYear!}/${courseInfo.conclusionYear!}';
+  }
+
   @override
   Widget build(BuildContext context) {
     return GenericCard(
@@ -48,9 +60,7 @@ class CourseCard extends StatelessWidget {
                         : grayMiddle),
               ),
               Text(
-                courseInfo.conclusionYear == null
-                    ? 'now'
-                    : '${courseInfo.enrollmentYear}/${courseInfo.conclusionYear}',
+                _getYearText(),
                 style: Theme.of(context).textTheme.bodySmall?.apply(
                     color: selected
                         ? Theme.of(context).colorScheme.primary

--- a/packages/uni_ui/lib/courses/course_card.dart
+++ b/packages/uni_ui/lib/courses/course_card.dart
@@ -10,11 +10,13 @@ class CourseCard extends StatelessWidget {
     super.key,
     required this.courseInfo,
     required this.selected,
+    required this.nowText,
     required this.onTap,
   });
 
   final CourseInfo courseInfo;
   final bool selected;
+  final String nowText;
   final void Function() onTap;
 
   String _getYearText() {
@@ -23,7 +25,7 @@ class CourseCard extends StatelessWidget {
     }
 
     if (courseInfo.conclusionYear == null) {
-      return 'now';
+      return nowText;
     }
 
     return '${courseInfo.enrollmentYear!}/${courseInfo.conclusionYear!}';

--- a/packages/uni_ui/lib/courses/course_info.dart
+++ b/packages/uni_ui/lib/courses/course_info.dart
@@ -1,11 +1,11 @@
 class CourseInfo {
   final String abbreviation;
-  final int enrollmentYear;
+  final int? enrollmentYear;
   final int? conclusionYear;
 
   CourseInfo({
     required this.abbreviation,
-    required this.enrollmentYear,
+    this.enrollmentYear,
     this.conclusionYear,
   });
 }

--- a/packages/uni_ui/lib/courses/course_selection.dart
+++ b/packages/uni_ui/lib/courses/course_selection.dart
@@ -6,11 +6,13 @@ class CourseSelection extends StatelessWidget {
   final List<CourseInfo> courseInfos;
   final void Function(int) onSelected;
   final int selected;
+  final String nowText;
 
   CourseSelection({
     required this.courseInfos,
     required this.onSelected,
     required this.selected,
+    required this.nowText,
   });
 
   @override
@@ -30,6 +32,7 @@ class CourseSelection extends StatelessWidget {
             courseInfo: courseInfos,
             selected: index == selected,
             onTap: () => {onSelected(index)},
+            nowText: nowText,
           );
         }).toList(),
       ),


### PR DESCRIPTION
# Description

Closes #1504. The problem occurs because some courses have only one curricular unit associated with no ECTS, failing in some NaNs (due to divisions by zero) and null checks.

<p align="center">
    <img alt="flutter_01" width=300 src="https://github.com/user-attachments/assets/5550ced7-e431-4317-8441-b7b49181105d">
</p>

# Changes Made

- Added checks to handle cases where the UCs do not have ECTS, along with the whole course in the average bar
- Improved some info displayed on such cases (average)
- Added translations to "now" text

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [X] If PR includes UI updates/additions, its description has screenshots
-   [X] Behavior is as expected
-   [X] Clean, well-structured code
