### PR TITLE
Fix infinite home page rebuild

### DIFF
--- a/packages/uni_app/lib/view/home/home.dart
+++ b/packages/uni_app/lib/view/home/home.dart
@@ -159,7 +159,7 @@ class HomePageViewState extends State<HomePageView> {
                 LazyConsumer<LectureProvider, List<Lecture>>(
                   builder: (context, lectures) {
                     WidgetsBinding.instance.addPostFrameCallback((_) {
-                      if (lectures.isNotEmpty) {
+                      if (lectures.isNotEmpty && appBarSize != 200) {
                         setState(() {
                           appBarSize = 200;
                         });


### PR DESCRIPTION
Closes #1544 
Now the `postFrameCallback` only causes a rebuild if the state actually changes.

# Review checklist
-   [x] Terms and conditions reflect the current change
-   [x] Contains enough appropriate tests
-   [x] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [x] If PR includes UI updates/additions, its description has screenshots
-   [x] Behavior is as expected
-   [x] Clean, well-structured code


## Before

Even without moving the screen it is constantly re-building and re-rendering!

<img src="https://github.com/user-attachments/assets/5c308c8f-de8f-409f-af34-fddb0a135250" width="300"/>

<img src="https://github.com/user-attachments/assets/a667c449-4e77-488a-a9cd-de3946da5ea1" width="300"/>

## After

It only re-builds and re-renders when interacted with (as it should).

<img src="https://github.com/user-attachments/assets/70e09577-441b-4765-b595-dffec1a2559c" width="300"/>