### PR TITLE
Changed the text in the statistic's banner

### DIFF
--- a/packages/uni_app/lib/generated/intl/messages_en.dart
+++ b/packages/uni_app/lib/generated/intl/messages_en.dart
@@ -81,7 +81,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "average": MessageLookupByLibrary.simpleMessage("Average"),
         "balance": MessageLookupByLibrary.simpleMessage("Balance"),
         "banner_info": MessageLookupByLibrary.simpleMessage(
-            "We do now collect anonymous usage statistics in order to improve your experience. You can change it in settings."),
+            "We collect anonymous usage data to help improve your experience. You can opt out anytime in the settings."),
         "bibliography": MessageLookupByLibrary.simpleMessage("Bibliography"),
         "breakfast": MessageLookupByLibrary.simpleMessage("Breakfast"),
         "bs_description": MessageLookupByLibrary.simpleMessage(

--- a/packages/uni_app/lib/generated/intl/messages_pt_PT.dart
+++ b/packages/uni_app/lib/generated/intl/messages_pt_PT.dart
@@ -81,7 +81,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "average": MessageLookupByLibrary.simpleMessage("Média"),
         "balance": MessageLookupByLibrary.simpleMessage("Saldo"),
         "banner_info": MessageLookupByLibrary.simpleMessage(
-            "Agora recolhemos estatísticas de uso anónimas para melhorar a tua experiência. Podes alterá-lo nas definições."),
+            "Recolhemos dados anónimos de utilização para ajudar a melhorar a sua experiência. Pode desativar esta opção a qualquer momento nas definições"),
         "bibliography": MessageLookupByLibrary.simpleMessage("Bibliografia"),
         "breakfast": MessageLookupByLibrary.simpleMessage("Pequeno Almoço"),
         "bs_description": MessageLookupByLibrary.simpleMessage(

--- a/packages/uni_app/lib/generated/l10n.dart
+++ b/packages/uni_app/lib/generated/l10n.dart
@@ -220,10 +220,10 @@ class S {
     );
   }
 
-  /// `We do now collect anonymous usage statistics in order to improve your experience. You can change it in settings.`
+  /// `We collect anonymous usage data to help improve your experience. You can opt out anytime in the settings.`
   String get banner_info {
     return Intl.message(
-      'We do now collect anonymous usage statistics in order to improve your experience. You can change it in settings.',
+      'We collect anonymous usage data to help improve your experience. You can opt out anytime in the settings.',
       name: 'banner_info',
       desc: '',
       args: [],

--- a/packages/uni_app/lib/l10n/intl_en.arb
+++ b/packages/uni_app/lib/l10n/intl_en.arb
@@ -34,7 +34,7 @@
   "@available_amount": {},
   "average": "Average",
   "@average": {},
-  "banner_info": "We do now collect anonymous usage statistics in order to improve your experience. You can change it in settings.",
+  "banner_info": "We collect anonymous usage data to help improve your experience. You can opt out anytime in the settings.",
   "@banner_info": {},
   "balance": "Balance",
   "@balance": {},

--- a/packages/uni_app/lib/l10n/intl_pt_PT.arb
+++ b/packages/uni_app/lib/l10n/intl_pt_PT.arb
@@ -36,7 +36,7 @@
   "@available_amount": {},
   "average": "Média",
   "@average": {},
-  "banner_info": "Agora recolhemos estatísticas de uso anónimas para melhorar a tua experiência. Podes alterá-lo nas definições.",
+  "banner_info": "Recolhemos dados anónimos de utilização para ajudar a melhorar a sua experiência. Pode desativar esta opção a qualquer momento nas definições",
   "@banner_info": {},
   "balance": "Saldo",
   "@balance": {},

--- a/packages/uni_app/lib/view/home/widgets/tracking_banner.dart
+++ b/packages/uni_app/lib/view/home/widgets/tracking_banner.dart
@@ -15,7 +15,7 @@ class TrackingBanner extends StatelessWidget {
             ? Theme.of(context).primaryColor
             : Theme.of(context).cardColor,
       ),
-      margin: const EdgeInsets.all(10),
+      margin: const EdgeInsets.only(top: 30, bottom: 10, left: 10, right: 10),
       child: MaterialBanner(
         padding: const EdgeInsets.all(15),
         content: Text(


### PR DESCRIPTION
Changed the text in the statistics banner, to avoid using the "We now". 
Also added more top-margin to avoid the overflow between the banner and the edit button

<div align="center">
<img src="https://github.com/user-attachments/assets/0d993431-5a92-4a63-892e-0133bd8e54ba" width="300px">
<img src="https://github.com/user-attachments/assets/32406f80-d9aa-493f-9e0e-0b1511e7d6db" width="300px">
</div>

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
