### PR TITLE
wrap scaffold in media query like in general page

### DIFF
--- a/packages/uni_app/lib/view/common_widgets/pages_layouts/secondary/secondary.dart
+++ b/packages/uni_app/lib/view/common_widgets/pages_layouts/secondary/secondary.dart
@@ -9,17 +9,21 @@ import 'package:uni/view/common_widgets/pages_layouts/general/widgets/top_naviga
 abstract class SecondaryPageViewState<T extends StatefulWidget>
     extends GeneralPageViewState<T> {
   @override
-  Scaffold getScaffold(BuildContext context, Widget body) {
-    return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.surface,
-      appBar: getTopNavbar(context),
-      bottomNavigationBar: const AppBottomNavbar(),
-      body: RefreshState(
-        onRefresh: onRefresh,
-        header: getHeader(context),
-        body: Padding(
-          padding: const EdgeInsets.only(right: 20, left: 20, bottom: 10),
-          child: getBody(context),
+  Widget getScaffold(BuildContext context, Widget body) {
+    return MediaQuery.removePadding(
+      context: context,
+      removeBottom: true,
+      child: Scaffold(
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        appBar: getTopNavbar(context),
+        bottomNavigationBar: const AppBottomNavbar(),
+        body: RefreshState(
+          onRefresh: onRefresh,
+          header: getHeader(context),
+          body: Padding(
+            padding: const EdgeInsets.only(right: 20, left: 20, bottom: 10),
+            child: getBody(context),
+          ),
         ),
       ),
     );

--- a/packages/uni_app/lib/view/map/map.dart
+++ b/packages/uni_app/lib/view/map/map.dart
@@ -58,111 +58,115 @@ class MapPageStateView extends State<MapPage> {
             });
           });
         }
-        return Scaffold(
-          resizeToAvoidBottomInset: false,
-          extendBody: true,
-          bottomNavigationBar: const AppBottomNavbar(),
-          body: FlutterMap(
-            options: MapOptions(
-              minZoom: 17,
-              maxZoom: 18,
-              nePanBoundary: const LatLng(41.17986, -8.59298),
-              swPanBoundary: const LatLng(41.17670, -8.59991),
-              center: const LatLng(41.17731, -8.59522),
-              zoom: 17.5,
-              interactiveFlags: InteractiveFlag.all - InteractiveFlag.rotate,
-              onTap: (tapPosition, latlng) =>
-                  _popupLayerController.hideAllPopups(),
-            ),
-            nonRotatedChildren: [
-              Align(
-                alignment: Alignment.bottomRight,
-                child: ColoredBox(
-                  color:
-                      Theme.of(context).colorScheme.onPrimary.withOpacity(0.8),
-                  child: GestureDetector(
-                    onTap: () => launchUrlWithToast(
-                      context,
-                      'https://www.openstreetmap.org/copyright',
-                    ),
-                    child: const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 5, horizontal: 8),
-                      child: MouseRegion(
-                        cursor: SystemMouseCursors.click,
-                        child: Text('©OpenStreetMap @CARTO'),
+        return MediaQuery.removePadding(
+          context: context,
+          removeBottom: true,
+          child: Scaffold(
+            resizeToAvoidBottomInset: false,
+            extendBody: true,
+            bottomNavigationBar: const AppBottomNavbar(),
+            body: FlutterMap(
+              options: MapOptions(
+                minZoom: 17,
+                maxZoom: 18,
+                nePanBoundary: const LatLng(41.17986, -8.59298),
+                swPanBoundary: const LatLng(41.17670, -8.59991),
+                center: const LatLng(41.17731, -8.59522),
+                zoom: 17.5,
+                interactiveFlags: InteractiveFlag.all - InteractiveFlag.rotate,
+                onTap: (tapPosition, latlng) =>
+                    _popupLayerController.hideAllPopups(),
+              ),
+              nonRotatedChildren: [
+                Align(
+                  alignment: Alignment.bottomRight,
+                  child: ColoredBox(
+                    color:
+                        Theme.of(context).colorScheme.onPrimary.withOpacity(0.8),
+                    child: GestureDetector(
+                      onTap: () => launchUrlWithToast(
+                        context,
+                        'https://www.openstreetmap.org/copyright',
+                      ),
+                      child: const Padding(
+                        padding: EdgeInsets.symmetric(vertical: 5, horizontal: 8),
+                        child: MouseRegion(
+                          cursor: SystemMouseCursors.click,
+                          child: Text('©OpenStreetMap @CARTO'),
+                        ),
                       ),
                     ),
                   ),
                 ),
-              ),
-            ],
-            children: <Widget>[
-              TileLayer(
-                urlTemplate:
-                    'https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png',
-                subdomains: const <String>['a', 'b', 'c'],
-                tileProvider: CachedTileProvider(),
-              ),
-              PopupMarkerLayer(
-                options: PopupMarkerLayerOptions(
-                  markers: filteredLocations.map((location) {
-                    return LocationMarker(location.latlng, location);
-                  }).toList(),
-                  popupController: _popupLayerController,
-                  popupDisplayOptions: PopupDisplayOptions(
-                    animation: const PopupAnimation.fade(
-                      duration: Duration(milliseconds: 400),
-                    ),
-                    builder: (_, marker) {
-                      if (marker is LocationMarker) {
-                        return marker.locationGroup.isFloorless
-                            ? FloorlessLocationMarkerPopup(marker.locationGroup)
-                            : LocationMarkerPopup(marker.locationGroup);
-                      }
-                      return const Card(child: Text(''));
-                    },
-                  ),
+              ],
+              children: <Widget>[
+                TileLayer(
+                  urlTemplate:
+                      'https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png',
+                  subdomains: const <String>['a', 'b', 'c'],
+                  tileProvider: CachedTileProvider(),
                 ),
-              ),
-              SafeArea(
-                child: Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
-                  child: PhysicalModel(
-                    borderRadius: BorderRadius.circular(10),
-                    color: Colors.white,
-                    elevation: 3,
-                    child: TextFormField(
-                      key: searchFormKey,
-                      onChanged: (text) {
-                        setState(() {
-                          searchTerms =
-                              removeDiacritics(text.trim().toLowerCase());
-                        });
+                PopupMarkerLayer(
+                  options: PopupMarkerLayerOptions(
+                    markers: filteredLocations.map((location) {
+                      return LocationMarker(location.latlng, location);
+                    }).toList(),
+                    popupController: _popupLayerController,
+                    popupDisplayOptions: PopupDisplayOptions(
+                      animation: const PopupAnimation.fade(
+                        duration: Duration(milliseconds: 400),
+                      ),
+                      builder: (_, marker) {
+                        if (marker is LocationMarker) {
+                          return marker.locationGroup.isFloorless
+                              ? FloorlessLocationMarkerPopup(marker.locationGroup)
+                              : LocationMarkerPopup(marker.locationGroup);
+                        }
+                        return const Card(child: Text(''));
                       },
-                      decoration: InputDecoration(
-                        filled: true,
-                        fillColor: Theme.of(context).colorScheme.secondary,
-                        prefixIcon: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 10),
-                          child: SvgPicture.asset(
-                            'assets/images/logo_dark.svg',
-                            semanticsLabel: 'search',
-                            width: 10,
+                    ),
+                  ),
+                ),
+                SafeArea(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+                    child: PhysicalModel(
+                      borderRadius: BorderRadius.circular(10),
+                      color: Colors.white,
+                      elevation: 3,
+                      child: TextFormField(
+                        key: searchFormKey,
+                        onChanged: (text) {
+                          setState(() {
+                            searchTerms =
+                                removeDiacritics(text.trim().toLowerCase());
+                          });
+                        },
+                        decoration: InputDecoration(
+                          filled: true,
+                          fillColor: Theme.of(context).colorScheme.secondary,
+                          prefixIcon: Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 10),
+                            child: SvgPicture.asset(
+                              'assets/images/logo_dark.svg',
+                              semanticsLabel: 'search',
+                              width: 10,
+                            ),
                           ),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(10),
+                            borderSide: BorderSide.none,
+                          ),
+                          contentPadding: const EdgeInsets.all(10),
+                          hintText: '${S.of(context).search}...',
                         ),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(10),
-                          borderSide: BorderSide.none,
-                        ),
-                        contentPadding: const EdgeInsets.all(10),
-                        hintText: '${S.of(context).search}...',
                       ),
                     ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         );
       },


### PR DESCRIPTION
Closes #1601 
wrapped scaffold in media query like in general page

<img src="https://github.com/user-attachments/assets/c43fb735-055f-43c7-a2c7-a4690b2e0cb4" width=350></img>



# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
