### PR TITLE
Riverpod migration

### DIFF
--- a/packages/uni_app/lib/model/providers/riverpod/cached_async_notifier.dart
+++ b/packages/uni_app/lib/model/providers/riverpod/cached_async_notifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uni/controller/local_storage/preferences_controller.dart';
 
 abstract class CachedAsyncNotifier<T> extends AsyncNotifier<T?> {
-  Duration get cacheDuration;
+  Duration? get cacheDuration;
 
   Future<T?> loadFromStorage();
 
@@ -11,10 +11,10 @@ abstract class CachedAsyncNotifier<T> extends AsyncNotifier<T?> {
   DateTime? _lastUpdateTime;
 
   bool get _isCacheValid {
-    if (_lastUpdateTime == null) {
+    if (_lastUpdateTime == null || cacheDuration == null) {
       return false;
     }
-    return DateTime.now().difference(_lastUpdateTime!) < cacheDuration;
+    return DateTime.now().difference(_lastUpdateTime!) < cacheDuration!;
   }
 
   @override

--- a/packages/uni_app/lib/model/providers/riverpod/cached_async_notifier.dart
+++ b/packages/uni_app/lib/model/providers/riverpod/cached_async_notifier.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uni/controller/local_storage/preferences_controller.dart';
+
+abstract class CachedAsyncNotifier<T> extends AsyncNotifier<T?> {
+  Duration get cacheDuration;
+
+  Future<T?> loadFromStorage();
+
+  Future<T?> loadFromRemote();
+
+  DateTime? _lastUpdateTime;
+
+  bool get _isCacheValid {
+    if (_lastUpdateTime == null) {
+      return false;
+    }
+    return DateTime.now().difference(_lastUpdateTime!) < cacheDuration;
+  }
+
+  @override
+  Future<T?> build() async {
+    _lastUpdateTime = PreferencesController.getLastDataClassUpdateTime(
+      runtimeType.toString(),
+    );
+
+    final localData = await loadFromStorage();
+    if (localData != null) {
+      state = AsyncData(localData);
+      _lastUpdateTime ??= DateTime.now();
+    }
+
+    if (localData == null || !_isCacheValid) {
+      try {
+        final remoteData = await loadFromRemote();
+        if (remoteData != null) {
+          _lastUpdateTime = DateTime.now();
+          state = AsyncData(remoteData);
+          return remoteData;
+        }
+      } catch (err, st) {
+        state = AsyncError(err, st);
+        rethrow;
+      }
+    }
+
+    return localData;
+  }
+
+  Future<T?> refreshRemote() async {
+    try {
+      final remoteData = await loadFromRemote();
+      if (remoteData != null) {
+        _lastUpdateTime = DateTime.now();
+        state = AsyncData(remoteData);
+      }
+
+      return remoteData;
+    } catch (err, st) {
+      state = AsyncError(err, st);
+      rethrow;
+    }
+  }
+
+  void updateState(T newState) {
+    state = AsyncData(newState);
+    _lastUpdateTime = DateTime.now();
+  }
+
+  void invalidate() {
+    state = AsyncData(null);
+    _lastUpdateTime = null;
+  }
+}

--- a/packages/uni_app/lib/model/providers/riverpod/session_provider.dart
+++ b/packages/uni_app/lib/model/providers/riverpod/session_provider.dart
@@ -1,0 +1,75 @@
+import 'package:uni/controller/background_workers/notifications.dart';
+import 'package:uni/controller/fetchers/terms_and_conditions_fetcher.dart';
+import 'package:uni/controller/local_storage/preferences_controller.dart';
+import 'package:uni/controller/networking/network_router.dart';
+import 'package:uni/model/providers/riverpod/cached_async_notifier.dart';
+import 'package:uni/session/authentication_controller.dart';
+import 'package:uni/session/flows/base/initiator.dart';
+import 'package:uni/session/flows/base/session.dart';
+import 'package:uni/session/logout/uni_logout_handler.dart';
+
+class SessionProvider extends CachedAsyncNotifier<Session?> {
+  @override
+  Duration? get cacheDuration => null;
+
+  AuthenticationController get controller =>
+      NetworkRouter.authenticationController!;
+
+  void _initController(Session session) {
+    NetworkRouter.authenticationController = AuthenticationController(
+      session,
+      logoutHandler: UniLogoutHandler(),
+    );
+  }
+
+  @override
+  Future<Session?> loadFromStorage() async {
+    final session = await PreferencesController.getSavedSession();
+    if (session != null) {
+      _initController(session);
+    }
+
+    return session;
+  }
+
+  @override
+  Future<Session?> loadFromRemote() async {
+    if (state.value == null) {
+      return null;
+    }
+
+    final oldSnapshot = await controller.snapshot;
+    await oldSnapshot.invalidate();
+
+    final newSnapshot = await controller.snapshot;
+    final newSession = newSnapshot.session;
+
+    if (await PreferencesController.isSessionPersistent()) {
+      await PreferencesController.saveSession(newSession);
+    }
+
+    return newSession;
+  }
+
+  Future<void> login(
+    SessionInitiator initiator, {
+    required bool persistentSession,
+  }) async {
+    final request = await initiator.initiate();
+    final session = await request.perform();
+
+    _initController(session);
+    updateState(session);
+
+    if (persistentSession) {
+      await PreferencesController.saveSession(session);
+    }
+
+    Future.delayed(
+      const Duration(seconds: 20),
+      () => {NotificationManager().initializeNotifications()},
+    );
+
+    await acceptTermsAndConditions();
+  }
+}


### PR DESCRIPTION
Closes #[issue number]
Draft of the port from simple `provider` package to `riverpod`.

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
