### PR TITLE
fix: updated version in `build.gradle`

### DIFF
--- a/packages/uni_app/android/app/build.gradle
+++ b/packages/uni_app/android/app/build.gradle
@@ -96,8 +96,8 @@ configurations {
 }
 
 dependencies {
-    implementation "io.objectbox:objectbox-android:4.1.0"
-    debugImplementation("io.objectbox:objectbox-android-objectbrowser:4.1.0")
+    implementation "io.objectbox:objectbox-android:4.3.0"
+    debugImplementation("io.objectbox:objectbox-android-objectbrowser:4.3.0")
 
     // The following 3 lines are a workaround for the Flutter issue.
     // Learn more: https://github.com/flutter/flutter/issues/110658


### PR DESCRIPTION
An iPhone user forgot to update the objectbox version for android in `build.gradle`.
Average iPhone user L