### PR TITLE
Fixed error in android notification permission request

### DIFF
--- a/packages/uni_app/lib/controller/background_workers/notifications.dart
+++ b/packages/uni_app/lib/controller/background_workers/notifications.dart
@@ -77,7 +77,7 @@ class NotificationManager {
 
   static Future<void> _initFlutterNotificationsPlugin() async {
     const initializationSettingsAndroid = AndroidInitializationSettings(
-      'ic_launcher',
+      '@mipmap/ic_launcher',
     );
 
     // request for notifications immediatly on iOS


### PR DESCRIPTION
When running in debug mode and the app was not installed on the device, this error would popup every now and then. It is now fixed.