### PR TITLE
hotfix: capture event on credentials login

### DIFF
--- a/packages/uni_app/lib/sigarra/endpoints/html/authentication/login/login.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/html/authentication/login/login.dart
@@ -64,7 +64,7 @@ class Login extends Endpoint<LoginResponse> {
       throw Exception('Could not find failure reason');
     } catch (err, st) {
       unawaited(
-        Sentry.captureException(
+        Sentry.captureEvent(
           SentryEvent(
             throwable: err,
             request: SentryRequest(data: document.outerHtml),


### PR DESCRIPTION
Properly captures the created event.

Currently, in Sentry, an exception is reported but it is serialized as `Instance of 'SentryEvent'` due to the typo.

# Review checklist

- [x] Terms and conditions reflect the changes

## View Changes

- [x] Description has screenshots of the UI changes.
- [x] Tested both in light and dark mode.
- [x] New text is both in portuguese (PT) and english (EN).
- [x] Works in different text zoom levels.
- [x] Works in different screen sizes.

## Performance

- [x] No helper functions to return widgets are added. New widgets are created instead.
- [x] Used ListView.builder for Long Lists.
- [x] Controllers (TextEditingController, ...) are beeing  disposed of in dispose() method.
