### PR TITLE
hotfix: fix credentials login

### DIFF
--- a/packages/uni_app/lib/sigarra/endpoints/html/authentication/login/login.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/html/authentication/login/login.dart
@@ -4,6 +4,7 @@ import 'package:html/dom.dart' as html;
 import 'package:html/parser.dart' as html_parser;
 import 'package:http/http.dart' as http;
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:uni/http/utils.dart';
 import 'package:uni/sigarra/endpoint.dart';
 import 'package:uni/sigarra/endpoints/html/authentication/login/response.dart';
 import 'package:uni/sigarra/options.dart';
@@ -37,7 +38,7 @@ class Login extends Endpoint<LoginResponse> {
     final document = html_parser.parse(response.body);
 
     if (_isSucessfulResponse(document)) {
-      return const LoginResponse(success: true);
+      return LoginSuccessfulResponse(cookies: extractCookies(response));
     }
 
     final failureReason = _parseFailureReason(document);
@@ -45,8 +46,13 @@ class Login extends Endpoint<LoginResponse> {
   }
 
   bool _isSucessfulResponse(html.Document document) {
-    final refresh = document.head?.querySelector("meta[http-equiv='refresh']");
-    return refresh != null;
+    final httpEquivTags =
+        document.head
+            ?.querySelectorAll('meta[http-equiv]')
+            .map((el) => el.attributes['http-equiv']?.toLowerCase()) ??
+        [];
+
+    return httpEquivTags.contains('refresh');
   }
 
   LoginFailureReason _parseFailureReason(html.Document document) {

--- a/packages/uni_app/lib/sigarra/endpoints/html/authentication/login/response.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/html/authentication/login/response.dart
@@ -1,9 +1,18 @@
+import 'dart:io';
+
 import 'package:uni/sigarra/response.dart';
 
 class LoginResponse extends EndpointResponse {
   const LoginResponse({required super.success});
 
+  LoginSuccessfulResponse asSuccessful() => this as LoginSuccessfulResponse;
   LoginFailedResponse asFailed() => this as LoginFailedResponse;
+}
+
+class LoginSuccessfulResponse extends LoginResponse {
+  const LoginSuccessfulResponse({required this.cookies}) : super(success: true);
+
+  final List<Cookie> cookies;
 }
 
 enum LoginFailureReason {

--- a/packages/uni_app/lib/sigarra/endpoints/html/home/home.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/html/home/home.dart
@@ -1,0 +1,43 @@
+import 'dart:async';
+
+import 'package:html/parser.dart' as html_parser;
+import 'package:http/http.dart' as http;
+import 'package:uni/sigarra/endpoint.dart';
+import 'package:uni/sigarra/endpoints/html/home/response.dart';
+import 'package:uni/sigarra/options.dart';
+
+class Home extends Endpoint<HomeResponse> {
+  const Home({this.options});
+
+  final FacultyRequestOptions? options;
+
+  @override
+  Future<HomeResponse> call() async {
+    final options = this.options ?? FacultyRequestOptions();
+
+    final loginUrl = options.baseUrl.resolve('web_page.inicial');
+
+    final response = await options.client.get(loginUrl);
+
+    return _parse(response);
+  }
+
+  Future<HomeResponse> _parse(http.Response response) async {
+    if (response.statusCode != 200) {
+      return const HomeResponse(success: false);
+    }
+
+    final document = html_parser.parse(response.body);
+
+    final authenticatedHeader = document.querySelector('.autenticado');
+    if (authenticatedHeader == null) {
+      return const HomeSuccessfulResponse(authenticated: false);
+    }
+
+    final photo = authenticatedHeader.querySelector('.fotografia img');
+    final photoUrl =
+        photo == null ? null : Uri.tryParse(photo.attributes['src'] ?? '');
+
+    return HomeAuthenticatedResponse(photoUrl: photoUrl);
+  }
+}

--- a/packages/uni_app/lib/sigarra/endpoints/html/home/response.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/html/home/response.dart
@@ -1,0 +1,24 @@
+import 'package:uni/sigarra/response.dart';
+
+class HomeResponse extends EndpointResponse {
+  const HomeResponse({required super.success});
+
+  HomeSuccessfulResponse asSuccessful() => this as HomeSuccessfulResponse;
+}
+
+class HomeSuccessfulResponse extends HomeResponse {
+  const HomeSuccessfulResponse({required this.authenticated})
+    : super(success: true);
+
+  final bool authenticated;
+
+  HomeAuthenticatedResponse asAuthenticated() =>
+      this as HomeAuthenticatedResponse;
+}
+
+class HomeAuthenticatedResponse extends HomeSuccessfulResponse {
+  const HomeAuthenticatedResponse({required this.photoUrl})
+    : super(authenticated: true);
+
+  final Uri? photoUrl;
+}

--- a/packages/uni_app/lib/sigarra/endpoints/html/html.dart
+++ b/packages/uni_app/lib/sigarra/endpoints/html/html.dart
@@ -1,7 +1,10 @@
 import 'package:uni/sigarra/endpoints/html/authentication/authentication.dart';
+import 'package:uni/sigarra/endpoints/html/home/home.dart';
 import 'package:uni/utils/lazy.dart';
 
 class SigarraHtml {
   final _authentication = Lazy(SigarraHtmlAuthentication.new);
   SigarraHtmlAuthentication get authentication => _authentication.value;
+
+  final home = Home.new;
 }


### PR DESCRIPTION
Fixes the credential login.

It appears that the API route has stopped working.
As such, we now need to fully switch to the HTML-based approach.

However, I needed to modify it to properly get the user's username. The new method is to go to the home page of FEUP and extract the username from the student photo URL.

# Review checklist

- [x] Terms and conditions reflect the changes

## View Changes

- [x] Description has screenshots of the UI changes.
- [x] Tested both in light and dark mode.
- [x] New text is both in portuguese (PT) and english (EN).
- [x] Works in different text zoom levels.
- [x] Works in different screen sizes.

## Performance

- [x] No helper functions to return widgets are added. New widgets are created instead.
- [x] Used ListView.builder for Long Lists.
- [x] Controllers (TextEditingController, ...) are beeing  disposed of in dispose() method.
