### PR TITLE
fix: fixed lectures cache

### DIFF
--- a/packages/uni_app/lib/model/providers/riverpod/lecture_provider.dart
+++ b/packages/uni_app/lib/model/providers/riverpod/lecture_provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logger/logger.dart';
 import 'package:uni/controller/fetchers/schedule_fetcher/schedule_fetcher_new_api.dart';
 import 'package:uni/controller/local_storage/database/database.dart';
-import 'package:logger/logger.dart';
 import 'package:uni/model/entities/lecture.dart';
 import 'package:uni/model/providers/riverpod/cached_async_notifier.dart';
 import 'package:uni/model/providers/riverpod/session_provider.dart';


### PR DESCRIPTION
Closes #1685
lectures were not being saved to the database, and were always being fetched from remote. 

`Database().saveLectures(lectures);` was not being called



# Review checklist

- [x] Terms and conditions reflect the changes

## View Changes

- [ ] Description has screenshots of the UI changes.
- [ ] Tested both in light and dark mode.
- [ ] New text is both in portuguese (PT) and english (EN).
- [ ] Works in different text zoom levels.
- [ ] Works in different screen sizes.

## Performance

- [ ] No helper functions to return widgets are added. New widgets are created instead.
- [ ] Used ListView.builder for Long Lists.
- [ ] Controllers (TextEditingController, ...) are beeing  disposed of in dispose() method.
