### PR TITLE
fix: app performance on pages with keyboard input

### DIFF
--- a/packages/uni_app/lib/view/map/map.dart
+++ b/packages/uni_app/lib/view/map/map.dart
@@ -195,7 +195,7 @@ class MapPageStateView extends ConsumerState<MapPage> {
                 ),
                 Padding(
                   padding: EdgeInsets.only(
-                    bottom: MediaQuery.viewPaddingOf(context).bottom + 110,
+                    bottom: MediaQuery.of(context).viewPadding.bottom + 110,
                     left: 20,
                   ),
                   child: Align(

--- a/packages/uni_app/lib/view/map/map.dart
+++ b/packages/uni_app/lib/view/map/map.dart
@@ -66,7 +66,6 @@ class MapPageStateView extends ConsumerState<MapPage> {
             });
           });
         }
-        //Hwello
 
         return AnnotatedRegion<SystemUiOverlayStyle>(
           value: AppSystemOverlayStyles.base.copyWith(
@@ -196,7 +195,7 @@ class MapPageStateView extends ConsumerState<MapPage> {
                 ),
                 Padding(
                   padding: EdgeInsets.only(
-                    bottom: MediaQuery.of(context).viewPadding.bottom + 110,
+                    bottom: MediaQuery.viewPaddingOf(context).bottom + 110,
                     left: 20,
                   ),
                   child: Align(

--- a/packages/uni_app/lib/view/map/map.dart
+++ b/packages/uni_app/lib/view/map/map.dart
@@ -66,6 +66,7 @@ class MapPageStateView extends ConsumerState<MapPage> {
             });
           });
         }
+        //Hwello
 
         return AnnotatedRegion<SystemUiOverlayStyle>(
           value: AppSystemOverlayStyles.base.copyWith(

--- a/packages/uni_app/lib/view/map/map.dart
+++ b/packages/uni_app/lib/view/map/map.dart
@@ -85,6 +85,7 @@ class MapPageStateView extends ConsumerState<MapPage> {
                 initialCameraFit: CameraFit.insideBounds(bounds: bounds),
                 cameraConstraint: CameraConstraint.containCenter(
                   bounds: bounds,
+                  //A
                 ),
                 onTap:
                     (tapPosition, latlng) =>

--- a/packages/uni_app/lib/view/map/map.dart
+++ b/packages/uni_app/lib/view/map/map.dart
@@ -85,7 +85,6 @@ class MapPageStateView extends ConsumerState<MapPage> {
                 initialCameraFit: CameraFit.insideBounds(bounds: bounds),
                 cameraConstraint: CameraConstraint.containCenter(
                   bounds: bounds,
-                  //A
                 ),
                 onTap:
                     (tapPosition, latlng) =>

--- a/packages/uni_ui/lib/navbar/bottom_navbar.dart
+++ b/packages/uni_ui/lib/navbar/bottom_navbar.dart
@@ -15,13 +15,13 @@ class _BottomNavbarContainer extends StatelessWidget {
       decoration: ShapeDecoration(
         color: Theme.of(context).colorScheme.primary,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-        shadows: [
+        /*shadows: [
           BoxShadow(
             color: Theme.of(context).colorScheme.shadow.withAlpha(0x7f),
             blurRadius: 5,
             offset: Offset(0, 3),
           ),
-        ],
+        ],  This currently makes the keyboard on the map page super buggy and slow*/
       ),
       child: GenericSquircle(
         child: Container(


### PR DESCRIPTION
Closes #1710

Currently, the keyboard in the map page and in the bug report page is really slow. When clicking any text field, the keyboard has a massive delay that is linked to performance issues regarding the shadows of some widgets.
More specifically this section of the bottom navigation bar. ``
```
        /*shadows: [
          BoxShadow(
            color: Theme.of(context).colorScheme.shadow.withAlpha(0x7f),
            blurRadius: 5,
            offset: Offset(0, 3),
          ),
        ],  This currently makes the keyboard on the map page super buggy and slow*/
```

When removing this section of the code, the keyboard is loaded at a normal speed and appears to be not as buggy and slow as before. Also when removing said section the visual identity of the bottom navigation remains the same with very small to no differences.

# Review checklist

- [ ] Terms and conditions reflect the changes

## View Changes

- [ ] Description has screenshots of the UI changes.
- [ ] Tested both in light and dark mode.
- [ ] New text is both in portuguese (PT) and english (EN).
- [ ] Works in different text zoom levels.
- [ ] Works in different screen sizes.

## Performance

- [ ] No helper functions to return widgets are added. New widgets are created instead.
- [ ] Used ListView.builder for Long Lists.
- [ ] Controllers (TextEditingController, ...) are beeing  disposed of in dispose() method.
