### PR TITLE
fix: added maxLines to calendar item card

### DIFF
--- a/packages/uni_ui/lib/calendar/calendar_item.dart
+++ b/packages/uni_ui/lib/calendar/calendar_item.dart
@@ -168,6 +168,8 @@ class CalendarItem extends StatelessWidget {
             ),
             child: Text(
               eventName,
+              maxLines: 4,
+              overflow: TextOverflow.ellipsis,
               style: TextStyle(
                 color:
                     isToday


### PR DESCRIPTION
added a cap to the lines of text a calendar item card can have to avoid that big white space under the smaller cards

<table>
<tr>
 <td> before
 <td> after
<tr>
 <td> <img width="350" alt="IMG_4542" src="https://github.com/user-attachments/assets/0206d8e6-7593-43cd-b6e4-6db31ebf0168" />
 <td> <img width="350" alt="IMG_4541" src="https://github.com/user-attachments/assets/37dfbaee-c09d-476a-b613-feb6de296a86" />
</table>





# Review checklist

- [ ] Terms and conditions reflect the changes

## View Changes

- [ ] Description has screenshots of the UI changes.
- [x] Tested both in light and dark mode.
- [ ] New text is both in portuguese (PT) and english (EN).
- [ ] Works in different text zoom levels.
- [ ] Works in different screen sizes.

## Performance

- [ ] No helper functions to return widgets are added. New widgets are created instead.
- [ ] Used ListView.builder for Long Lists.
- [ ] Controllers (TextEditingController, ...) are beeing  disposed of in dispose() method.
