### PR TITLE
add space between event and screen in faculty calendar

### DIFF
--- a/packages/uni_ui/lib/calendar/calendar.dart
+++ b/packages/uni_ui/lib/calendar/calendar.dart
@@ -15,7 +15,7 @@ class CalendarLine extends StatelessWidget {
       child: Row(
         children: [
           Container(
-            width: 60,
+            width: 80,
             height: 4,
             margin: const EdgeInsets.only(right: 15),
             decoration: BoxDecoration(
@@ -39,7 +39,7 @@ class CalendarLine extends StatelessWidget {
             ),
           ),
           Container(
-            width: 60,
+            width: 80,
             height: 4,
             margin: const EdgeInsets.only(left: 15),
             decoration: BoxDecoration(
@@ -94,9 +94,12 @@ class _CalendarState extends State<Calendar> {
       controller: _scrollController,
       child: Stack(
         children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: widget.items,
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: widget.items,
+            ),
           ),
           CalendarLine(calendarItemsCount: widget.items.length),
         ],


### PR DESCRIPTION
Closes #1743 

added padding between event and screen and extended calendar line (60px + 20px padding)

# Review checklist

- [ ] Terms and conditions reflect the changes

## View Changes

- [ ] Description has screenshots of the UI changes.
- [ ] Tested both in light and dark mode.
- [ ] New text is both in portuguese (PT) and english (EN).
- [ ] Works in different text zoom levels.
- [ ] Works in different screen sizes.

## Performance

- [ ] No helper functions to return widgets are added. New widgets are created instead.
- [ ] Used ListView.builder for Long Lists.
- [ ] Controllers (TextEditingController, ...) are beeing  disposed of in dispose() method.
