### PR TITLE
hotfix: schedule card

### DIFF
--- a/packages/uni_ui/lib/cards/schedule_card.dart
+++ b/packages/uni_ui/lib/cards/schedule_card.dart
@@ -112,17 +112,14 @@ class ScheduleCard extends StatelessWidget {
                         backgroundImage: teacherPhoto?.image,
                       ),
                       const SizedBox(width: 8), //TODO: create gap()?
-                      SizedBox(
-                        width: 140,
-                        child: Expanded(
-                          child: Text(
-                            teacherName!,
-                            overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                              color: isActive
-                                  ? Theme.of(context).colorScheme.secondary
-                                  : Theme.of(context).colorScheme.primary,
-                            ),
+                      Expanded(
+                        child: Text(
+                          teacherName!,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            color: isActive
+                                ? Theme.of(context).colorScheme.secondary
+                                : Theme.of(context).colorScheme.primary,
                           ),
                         ),
                       ),


### PR DESCRIPTION
fixes the `Another exception was thrown: Incorrect use of ParentDataWidget.` error
 
`Expanded` should only be used in row, column or flex elements. removing this sizedbox seems to fix the problem. i dont know the purpose of that sizedbox was 🕊️ 


# Review checklist

- [ ] Terms and conditions reflect the changes

## View Changes

- [ ] Description has screenshots of the UI changes.
- [ ] Tested both in light and dark mode.
- [ ] New text is both in portuguese (PT) and english (EN).
- [ ] Works in different text zoom levels.
- [ ] Works in different screen sizes.

## Performance

- [ ] No helper functions to return widgets are added. New widgets are created instead.
- [ ] Used ListView.builder for Long Lists.
- [ ] Controllers (TextEditingController, ...) are beeing  disposed of in dispose() method.
