### PR TITLE
Fix the exam types error that were appearing after sigarra update

### DIFF
--- a/packages/uni_app/lib/controller/parsers/parser_exams.dart
+++ b/packages/uni_app/lib/controller/parsers/parser_exams.dart
@@ -33,7 +33,9 @@ class ParserExams {
     var days = 0;
     var tableNum = 0;
     document.querySelectorAll('h3').forEach((examType) {
-      examTypes.add(getExamSeasonAbbr(examType.text));
+      if (examType.nextElementSibling!.toString() == '<html table>') {
+        examTypes.add(getExamSeasonAbbr(examType.text));
+      }
     });
 
     final tdElements = document.querySelectorAll(


### PR DESCRIPTION
Closes #1850 

Due to a recent update in sigarra the exam types weren't being fetched correctly. In this sigarra update the exam page of a occurrence was changed, now including a new header h3 without a following table. We were saving every h3 text without checking if the next element was a table. This fix consists on checking if the next element is a table before adding it to the examTypes. 

# Review checklist

- [ ] Terms and conditions reflect the changes

## View Changes

- [ ] Description has screenshots of the UI changes.
- [ ] Tested both in light and dark mode.
- [ ] New text is both in portuguese (PT) and english (EN).
- [ ] Works in different text zoom levels.
- [ ] Works in different screen sizes.

## Performance

- [ ] No helper functions to return widgets are added. New widgets are created instead.
- [ ] Used ListView.builder for Long Lists.
- [ ] Controllers (TextEditingController, ...) are beeing  disposed of in dispose() method.
