### PR TITLE
hot-fix: added new required API key to CARTO api call

### DIFF
--- a/packages/uni_app/assets/env/.env.example
+++ b/packages/uni_app/assets/env/.env.example
@@ -1,3 +1,3 @@
-# Plausbile
 PLAUSIBLE_URL=https://plausible.example.com
 PLAUSIBLE_DOMAIN=your.plausible.domain
+CARTO_API_KEY=your.carto.api.key

--- a/packages/uni_app/lib/view/map/map.dart
+++ b/packages/uni_app/lib/view/map/map.dart
@@ -1,11 +1,13 @@
 import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_popup/flutter_map_marker_popup.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:logger/logger.dart';
 import 'package:uni/controller/networking/url_launcher.dart';
 import 'package:uni/generated/l10n.dart';
 import 'package:uni/model/entities/indoor_floor_plan.dart';
@@ -188,7 +190,7 @@ class MapPageStateView extends ConsumerState<MapPage> {
       ...locationFloors,
       ...indoorFloors,
     }.where((f) => f != 7).toList()..sort((a, b) => b.compareTo(a));
-
+    
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: AppSystemOverlayStyles.base.copyWith(
         statusBarIconBrightness: Theme.of(context).brightness == Brightness.dark
@@ -225,8 +227,11 @@ class MapPageStateView extends ConsumerState<MapPage> {
           children: <Widget>[
             TileLayer(
               urlTemplate: Theme.of(context).brightness == Brightness.dark
-                  ? 'https://basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png'
-                  : 'https://basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png',
+                  ? 'https://basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png?key={apiKey}'
+                  : 'https://basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png?key={apiKey}',
+              additionalOptions: {
+                'apiKey': dotenv.env['CARTO_API_KEY'] ?? '',
+              },
               tileProvider: NetworkTileProvider(
                 cachingProvider:
                     BuiltInMapCachingProvider.getOrCreateInstance(),

--- a/packages/uni_app/lib/view/map/map.dart
+++ b/packages/uni_app/lib/view/map/map.dart
@@ -7,7 +7,6 @@ import 'package:flutter_map_marker_popup/flutter_map_marker_popup.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:latlong2/latlong.dart';
-import 'package:logger/logger.dart';
 import 'package:uni/controller/networking/url_launcher.dart';
 import 'package:uni/generated/l10n.dart';
 import 'package:uni/model/entities/indoor_floor_plan.dart';
@@ -190,7 +189,7 @@ class MapPageStateView extends ConsumerState<MapPage> {
       ...locationFloors,
       ...indoorFloors,
     }.where((f) => f != 7).toList()..sort((a, b) => b.compareTo(a));
-    
+
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: AppSystemOverlayStyles.base.copyWith(
         statusBarIconBrightness: Theme.of(context).brightness == Brightness.dark
@@ -229,9 +228,7 @@ class MapPageStateView extends ConsumerState<MapPage> {
               urlTemplate: Theme.of(context).brightness == Brightness.dark
                   ? 'https://basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png?key={apiKey}'
                   : 'https://basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png?key={apiKey}',
-              additionalOptions: {
-                'apiKey': dotenv.env['CARTO_API_KEY'] ?? '',
-              },
+              additionalOptions: {'apiKey': dotenv.env['CARTO_API_KEY'] ?? ''},
               tileProvider: NetworkTileProvider(
                 cachingProvider:
                     BuiltInMapCachingProvider.getOrCreateInstance(),


### PR DESCRIPTION
The CARTO service (used for the map) now requires an API key to all api calls. This pr fixes it by adding the api to the url by query paramaters.

I already added the env CART_API_KEY to the UNI_ENV_FILE

Closes #[issue number]
<!--
Description of the changes proposed in the pull request. 
Include steps to replicate the behavior and screenshots if UI is updated.
> If this is release PR select it's template by adding ?template=release_pr_template.md to the url.
-->

# Review checklist

- [ ] Terms and conditions reflect the changes

## View Changes

- [ ] Description has screenshots of the UI changes.
- [ ] Tested both in light and dark mode.
- [ ] New text is both in portuguese (PT) and english (EN).
- [ ] Works in different text zoom levels.
- [ ] Works in different screen sizes.

## Performance

- [ ] No helper functions to return widgets are added. New widgets are created instead.
- [ ] Used ListView.builder for Long Lists.
- [ ] Controllers (TextEditingController, ...) are beeing  disposed of in dispose() method.
